### PR TITLE
fix: package name, footer address placeholder, copyright year

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-example",
+  "name": "femme-events-website",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,10 +13,7 @@ export default function Footer() {
 
         <div className="flex flex-col gap-6">
           <h4 className="text-sm uppercase tracking-[0.2em] font-bold opacity-40">Location</h4>
-          <div className="text-base leading-relaxed">
-            123 Kitschy Lane<br />
-            Atlanta, GA 30301
-          </div>
+          <p className="text-base text-femme-dark/80">Serving Atlanta and surrounding areas</p>
         </div>
 
         <div className="flex flex-col gap-6">
@@ -47,7 +44,7 @@ export default function Footer() {
       </div>
 
       <div className="mt-20 pt-8 border-t border-femme-plum/5 flex justify-between items-center text-xs uppercase tracking-widest font-bold opacity-30">
-        <span>&copy; 2025 Femme Events</span>
+        <span>&copy; 2026 Femme Events</span>
         <span>All Rights Reserved</span>
       </div>
     </footer>


### PR DESCRIPTION
closes #2 , closes #3, closes #4 
## summary
- updates package.json name from 'react-example' to 'femme-events-websire'
- replaces footer placeholder address
- updates footer copyright year to 2026
