### PR TITLE
feat: Blog / Journal infrastructure (#14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "motion": "^12.23.24",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-router-dom": "^7.14.1",
         "vite": "^6.2.0"
       },
       "devDependencies": {
@@ -3411,6 +3412,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
+      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
+      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3568,6 +3620,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "motion": "^12.23.24",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-router-dom": "^7.14.1",
     "vite": "^6.2.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,24 +3,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Navbar from "./components/Navbar";
+import Footer from "./components/Footer";
 import Hero from "./components/Hero";
 import About from "./components/About";
 import Services from "./components/Services";
 import Testimonials from "./components/Testimonials";
 import Inquiry from "./components/Inquiry";
-import Footer from "./components/Footer";
+import BlogIndex from "./pages/BlogIndex";
+import BlogPost from "./pages/BlogPost";
 
-export default function App() {
+function Home() {
   return (
     <main className="relative min-h-screen">
-      <Navbar />
       <Hero />
       <About />
       <Services />
       <Testimonials />
       <Inquiry />
-      <Footer />
     </main>
+  );
+}
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Navbar />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/journal" element={<BlogIndex />} />
+        <Route path="/journal/:slug" element={<BlogPost />} />
+      </Routes>
+      <Footer />
+    </BrowserRouter>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,14 +1,26 @@
 import { useState, useEffect } from "react";
 import { motion } from "motion/react";
+import { NavLink, useLocation } from "react-router-dom";
 
 export default function Navbar() {
   const [scrolled, setScrolled] = useState(false);
+  const { pathname } = useLocation();
+  const isHome = pathname === "/";
 
   useEffect(() => {
+    // Non-home pages always show the scrolled (solid) navbar
+    if (!isHome) {
+      setScrolled(true);
+      return;
+    }
+    setScrolled(window.scrollY > 60);
     const handleScroll = () => setScrolled(window.scrollY > 60);
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+  }, [isHome]);
+
+  // Anchor links resolve correctly from any page
+  const anchor = (hash: string) => (isHome ? hash : `/${hash}`);
 
   return (
     <motion.nav
@@ -21,7 +33,7 @@ export default function Navbar() {
           : "bg-transparent"
       }`}
     >
-      <a href="#" aria-label="Femme Events home">
+      <a href={anchor("#")} aria-label="Femme Events home">
         <img
           src="/logo-nav.svg"
           alt="Femme Events"
@@ -35,9 +47,17 @@ export default function Navbar() {
           scrolled ? "text-femme-dark" : "text-white"
         }`}
       >
-        <a href="#about" className="hover:opacity-60 transition-opacity">About</a>
-        <a href="#services" className="hover:opacity-60 transition-opacity">Services</a>
-        <a href="#inquiry" className="hover:opacity-60 transition-opacity">Inquiry</a>
+        <a href={anchor("#about")} className="hover:opacity-60 transition-opacity">About</a>
+        <a href={anchor("#services")} className="hover:opacity-60 transition-opacity">Services</a>
+        <NavLink
+          to="/journal"
+          className={({ isActive }) =>
+            `hover:opacity-60 transition-opacity${isActive ? " opacity-60" : ""}`
+          }
+        >
+          Journal
+        </NavLink>
+        <a href={anchor("#inquiry")} className="hover:opacity-60 transition-opacity">Inquiry</a>
       </div>
     </motion.nav>
   );

--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -1,0 +1,153 @@
+export interface Post {
+  slug: string;
+  title: string;
+  excerpt: string;
+  category: string;
+  date: string;
+  readTime: string;
+  image: string;
+  body: string;
+}
+
+export const posts: Post[] = [
+  {
+    slug: "six-months-out-what-to-do-first",
+    title: "Six Months Out: The Moves That Actually Matter",
+    excerpt:
+      "Everyone tells you to book the venue first. But there are a few less-obvious decisions at the six-month mark that will quietly save your entire wedding.",
+    category: "Planning",
+    date: "April 10, 2026",
+    readTime: "5 min read",
+    image: "/photos/pt2.jpg",
+    body: `
+Six months feels like forever — until it doesn't. If you're sitting at the six-month mark and your to-do list looks like a CVS receipt, take a breath. Not everything on it matters equally.
+
+Here's what we've seen make or break the final stretch:
+
+## Lock your coordinator before your florist
+
+I know, I know — flowers are fun. Coordinators are logistics. But your coordinator will shape every single vendor relationship you build from here on out. We catch the conflicts in contracts before you sign them, we know which venues have tricky load-in rules, and we'll tell you the honest truth about whether that florist's "minimum" is going to blow your budget.
+
+Book coordination first. Then go enjoy flower appointments.
+
+## Have the "who sits where" conversation now
+
+Not the seating chart — that comes later. I mean the harder conversation: are your families going to be civil? Is there a guest situation your partner hasn't fully told their side of the family about? Is someone getting an invitation that's going to cause drama?
+
+Six months is enough runway to handle these conversations without panic. Two months is not.
+
+## Get your dress order timeline confirmed in writing
+
+Bridal boutiques will give you a verbal "oh that'll be fine" right up until it isn't. Get the production timeline, the delivery date, and the alteration window all documented. Ask specifically what happens if the dress arrives late. Ask it to their face. Watch the answer.
+
+Standard alterations take 6–8 weeks. If your dress arrives at the 10-week mark, you're cutting it close.
+
+## Build your vendor tip budget now
+
+Nobody talks about this. You will tip your photographer, your caterer's staff, your hair and makeup team, your coordinator, your DJ, and probably your venue coordinator too. On a wedding with 100 guests, that's easily $1,500–$2,500 in tips that couples forget to plan for.
+
+Put it in the budget now, while there's still room to adjust.
+
+## Stop looking at inspiration
+
+Seriously. At six months, you should be narrowing, not expanding. Every new inspiration board is a potential pivot that costs time and sometimes money. You have a vision. Protect it.
+
+---
+
+You don't need to do everything at once. You need to do the right things in the right order. That's what planning actually is.
+
+If you're not sure what your "right order" looks like — that's exactly what a partial planning consultation is for. [Let's chat.](#inquiry)
+    `.trim(),
+  },
+  {
+    slug: "day-of-coordination-myths",
+    title: "Day-of Coordination: What It Actually Includes (And What It Doesn't)",
+    excerpt:
+      "A lot of couples come to us thinking day-of coordination means someone shows up the morning of the wedding. It doesn't — and here's what you're actually getting.",
+    category: "Services",
+    date: "March 28, 2026",
+    readTime: "4 min read",
+    image: "/photos/pt3.jpg",
+    body: `
+The phrase "day-of coordination" is genuinely misleading. We've thought about lobbying to change the industry term. We haven't won that fight yet.
+
+Here's the reality:
+
+## We start weeks before the wedding
+
+A real day-of package begins with an initial consultation, a venue walkthrough, and a detailed review of every vendor contract you've already signed. We're looking for overlaps, gaps, and anything that looks like it could go sideways under pressure.
+
+At Femme Events, our day-of package includes:
+- One detailed venue walkthrough before the wedding
+- Full vendor contact collection and timeline distribution
+- A day-of timeline we build from scratch (not a template)
+- Rehearsal coordination the evening before
+- Two coordinators on the actual day, for eight hours
+
+That last part matters. One coordinator cannot be in the bridal suite and at the venue entrance at the same time. You need two.
+
+## What it doesn't include
+
+Day-of coordination is not design. It doesn't include vendor sourcing, mood boards, or budget management. If you want someone to help you figure out *what* your wedding looks like, that's partial planning.
+
+Day-of coordination assumes you've made the big decisions and you need someone to make sure they actually happen.
+
+## The question to ask yourself
+
+Have you already booked your venue, photographer, caterer, and florist? Do you know what the day is supposed to look like — you're just worried about execution?
+
+If yes: day-of is probably right for you.
+
+If you're still building the vision: let's talk about partial planning instead.
+
+---
+
+Not sure which package fits your situation? Fill out our inquiry form and we'll tell you honestly what you actually need.
+    `.trim(),
+  },
+  {
+    slug: "atlanta-wedding-venues-honest-take",
+    title: "Atlanta Wedding Venues: An Honest Take From Someone Who's Worked Them All",
+    excerpt:
+      "Beautiful photos don't tell you about the loading dock situation, the noise ordinance, or the fact that the bridal suite is the size of a closet. We do.",
+    category: "Venues",
+    date: "March 14, 2026",
+    readTime: "6 min read",
+    image: "/photos/kj1.jpg",
+    body: `
+Venue tours are designed to make you fall in love. They happen on sunny days, rooms are staged perfectly, and your tour guide has done this hundreds of times. Their job is to sell.
+
+Our job is to make sure you don't get surprised on your wedding day.
+
+Here's what we pay attention to on every walkthrough — and what you should be asking before you sign.
+
+## Where does the catering come in?
+
+This sounds boring. It is not boring. If the catering entrance is through the same hallway your guests use, your cocktail hour will smell like food before the reveal. If the kitchen is on a different floor from the reception space, service will be slow. Ask to see the load-in route.
+
+## What's the backup plan for outdoor ceremonies?
+
+Every venue with an outdoor ceremony space will tell you they have a backup plan. Ask to *see* the backup space. Actually walk into it. If the backup is a tent that holds 80% of your guest count and you're at 150, that's a problem you want to know about in February, not in June.
+
+## What does the bridal suite actually look like?
+
+Not the Instagram photos of the bridal suite. The actual suite, with the lights on, on a random Tuesday. How many outlets does it have? Is there a mirror large enough for hair and makeup? Will your entire bridal party fit? Will the photographer be able to work in it?
+
+## What's the noise ordinance?
+
+Atlanta venues vary wildly here. Some neighborhoods have strict cutoffs. Some venues have internal sound rules that don't match what they advertise. Know the hard stop before you book your DJ.
+
+## Does the venue have a preferred vendor list?
+
+If yes: are you required to use it, or is it just a recommendation? Required lists can limit your options significantly. Ask specifically about catering — some venues require in-house catering, which removes one of your biggest budget levers.
+
+---
+
+We've worked most of the major Atlanta and metro venues. If you're trying to narrow down your list and want a real, honest opinion — put it in your inquiry form. We'll tell you what we actually think.
+    `.trim(),
+  },
+];
+
+export function getPost(slug: string): Post | undefined {
+  return posts.find((p) => p.slug === slug);
+}

--- a/src/pages/BlogIndex.tsx
+++ b/src/pages/BlogIndex.tsx
@@ -1,0 +1,73 @@
+import { Link } from "react-router-dom";
+import { motion } from "motion/react";
+import { posts } from "../data/posts";
+
+export default function BlogIndex() {
+  return (
+    <div className="min-h-screen bg-femme-cream">
+      {/* Header */}
+      <section className="pt-40 pb-16 px-6 md:px-24 bg-femme-pale border-b border-femme-plum/10">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, ease: "easeOut" }}
+        >
+          <h1 className="text-8xl md:text-9xl text-femme-dark italic mb-4">The Journal</h1>
+          <div className="h-1 w-32 bg-femme-orange" />
+          <p className="mt-6 text-femme-dark/60 text-xl font-system max-w-xl">
+            Real talk on weddings, planning, and everything in between — from the people running the show.
+          </p>
+        </motion.div>
+      </section>
+
+      {/* Post grid */}
+      <section className="py-20 px-6 md:px-24">
+        <div className="grid md:grid-cols-3 gap-8">
+          {posts.map((post, index) => (
+            <motion.article
+              key={post.slug}
+              initial={{ opacity: 0, y: 24 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: index * 0.1, duration: 0.6, ease: "easeOut" }}
+            >
+              <Link to={`/journal/${post.slug}`} className="group block">
+                {/* Image */}
+                <div className="overflow-hidden rounded-2xl aspect-[4/3] mb-5">
+                  <img
+                    src={post.image}
+                    alt={post.title}
+                    className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+                  />
+                </div>
+
+                {/* Meta */}
+                <div className="flex items-center gap-3 mb-3 font-system">
+                  <span className="text-xs font-bold uppercase tracking-widest text-femme-plum">
+                    {post.category}
+                  </span>
+                  <span className="text-femme-dark/30">·</span>
+                  <span className="text-xs text-femme-dark/50">{post.readTime}</span>
+                </div>
+
+                {/* Title */}
+                <h2 className="text-2xl text-femme-dark leading-snug mb-3 group-hover:text-femme-plum transition-colors duration-200">
+                  {post.title}
+                </h2>
+
+                {/* Excerpt */}
+                <p className="text-femme-dark/60 text-base leading-relaxed font-system line-clamp-3">
+                  {post.excerpt}
+                </p>
+
+                {/* Date */}
+                <p className="mt-4 text-xs text-femme-dark/40 font-system uppercase tracking-widest">
+                  {post.date}
+                </p>
+              </Link>
+            </motion.article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/BlogIndex.tsx
+++ b/src/pages/BlogIndex.tsx
@@ -1,72 +1,198 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import { motion } from "motion/react";
-import { posts } from "../data/posts";
+import { motion, AnimatePresence } from "motion/react";
+import { ArrowRight } from "lucide-react";
+import { posts, type Post } from "../data/posts";
+
+const categories = ["All", ...Array.from(new Set(posts.map((p) => p.category)))];
+
+function FeaturedPost({ post }: { post: Post }) {
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.7, ease: "easeOut" }}
+      className="grid md:grid-cols-2 gap-0 rounded-2xl overflow-hidden border border-femme-plum/10 shadow-sm"
+    >
+      {/* Image */}
+      <div className="overflow-hidden aspect-[4/3] md:aspect-auto">
+        <img
+          src={post.image}
+          alt={post.title}
+          className="w-full h-full object-cover"
+        />
+      </div>
+
+      {/* Content */}
+      <div className="bg-femme-pale flex flex-col justify-center px-10 py-12 gap-5">
+        <div className="flex items-center gap-3 font-system">
+          <span className="text-xs font-bold uppercase tracking-widest text-femme-plum bg-femme-plum/10 px-3 py-1 rounded-full">
+            {post.category}
+          </span>
+          <span className="text-xs text-femme-dark/40">{post.date}</span>
+        </div>
+
+        <h2 className="text-4xl md:text-5xl text-femme-dark leading-tight italic">
+          {post.title}
+        </h2>
+
+        <p className="text-femme-dark/65 text-lg leading-relaxed font-system">
+          {post.excerpt}
+        </p>
+
+        <Link
+          to={`/journal/${post.slug}`}
+          className="inline-flex items-center gap-2 text-femme-plum font-bold text-sm uppercase tracking-widest font-system hover:gap-4 transition-all duration-200 w-fit"
+        >
+          Read Story <ArrowRight size={15} strokeWidth={2.5} />
+        </Link>
+      </div>
+    </motion.article>
+  );
+}
+
+function PostCard({ post, index }: { post: Post; index: number }) {
+  return (
+    <motion.article
+      layout
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 20 }}
+      transition={{ delay: index * 0.08, duration: 0.5, ease: "easeOut" }}
+      className="group flex flex-col gap-4 border-b border-femme-plum/10 pb-10"
+    >
+      {/* Image */}
+      <div className="overflow-hidden rounded-xl aspect-[16/9]">
+        <img
+          src={post.image}
+          alt={post.title}
+          className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+        />
+      </div>
+
+      {/* Meta */}
+      <div className="flex items-center gap-3 font-system">
+        <span className="text-xs font-bold uppercase tracking-widest text-femme-plum">
+          {post.category}
+        </span>
+        <span className="text-femme-dark/25">·</span>
+        <span className="text-xs text-femme-dark/45">{post.readTime}</span>
+        <span className="text-femme-dark/25">·</span>
+        <span className="text-xs text-femme-dark/45">{post.date}</span>
+      </div>
+
+      {/* Title */}
+      <h3 className="text-2xl text-femme-dark leading-snug group-hover:text-femme-plum transition-colors duration-200">
+        {post.title}
+      </h3>
+
+      {/* Excerpt */}
+      <p className="text-femme-dark/60 text-base leading-relaxed font-system line-clamp-2 flex-1">
+        {post.excerpt}
+      </p>
+
+      {/* CTA */}
+      <Link
+        to={`/journal/${post.slug}`}
+        className="inline-flex items-center gap-2 text-femme-plum font-bold text-sm uppercase tracking-widest font-system hover:gap-4 transition-all duration-200 w-fit"
+      >
+        Read Story <ArrowRight size={14} strokeWidth={2.5} />
+      </Link>
+    </motion.article>
+  );
+}
 
 export default function BlogIndex() {
+  const [activeCategory, setActiveCategory] = useState("All");
+
+  const featured = posts[0];
+  const rest = posts.slice(1);
+  const filtered = activeCategory === "All"
+    ? rest
+    : rest.filter((p) => p.category === activeCategory);
+
   return (
     <div className="min-h-screen bg-femme-cream">
       {/* Header */}
-      <section className="pt-40 pb-16 px-6 md:px-24 bg-femme-pale border-b border-femme-plum/10">
+      <section className="pt-40 pb-16 px-6 md:px-24 border-b border-femme-plum/10">
         <motion.div
           initial={{ opacity: 0, y: 24 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.7, ease: "easeOut" }}
+          className="flex flex-col md:flex-row md:items-end justify-between gap-6"
         >
-          <h1 className="text-8xl md:text-9xl text-femme-dark italic mb-4">The Journal</h1>
-          <div className="h-1 w-32 bg-femme-orange" />
-          <p className="mt-6 text-femme-dark/60 text-xl font-system max-w-xl">
-            Real talk on weddings, planning, and everything in between — from the people running the show.
+          <div>
+            <p className="text-femme-plum text-sm uppercase tracking-widest font-bold font-system mb-3">
+              Femme Events
+            </p>
+            <h1 className="text-8xl md:text-9xl text-femme-dark italic leading-none mb-4">
+              The Journal
+            </h1>
+            <div className="h-1 w-32 bg-femme-orange" />
+          </div>
+          <p className="text-femme-dark/55 text-xl font-system max-w-sm md:text-right leading-relaxed">
+            Real stories, honest planning advice, and the things we wish more couples knew.
           </p>
         </motion.div>
       </section>
 
-      {/* Post grid */}
-      <section className="py-20 px-6 md:px-24">
-        <div className="grid md:grid-cols-3 gap-8">
-          {posts.map((post, index) => (
-            <motion.article
-              key={post.slug}
-              initial={{ opacity: 0, y: 24 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: index * 0.1, duration: 0.6, ease: "easeOut" }}
+      {/* Featured post */}
+      <section className="py-14 px-6 md:px-24">
+        <p className="text-xs uppercase tracking-widest font-bold text-femme-dark/35 font-system mb-6">
+          Latest Story
+        </p>
+        <FeaturedPost post={featured} />
+      </section>
+
+      {/* Category filter + grid */}
+      <section className="px-6 md:px-24 pb-24">
+        {/* Divider + filter */}
+        <div className="flex flex-wrap items-center gap-2 border-t border-femme-plum/10 pt-10 mb-12">
+          <p className="text-xs uppercase tracking-widest font-bold text-femme-dark/35 font-system mr-4">
+            Browse by
+          </p>
+          {categories.map((cat) => (
+            <button
+              key={cat}
+              onClick={() => setActiveCategory(cat)}
+              className={`px-5 py-2 rounded-full text-xs font-bold uppercase tracking-widest font-system transition-colors duration-200 cursor-pointer border ${
+                activeCategory === cat
+                  ? "bg-femme-plum text-white border-femme-plum"
+                  : "bg-transparent text-femme-dark/55 border-femme-dark/15 hover:border-femme-plum hover:text-femme-plum"
+              }`}
             >
-              <Link to={`/journal/${post.slug}`} className="group block">
-                {/* Image */}
-                <div className="overflow-hidden rounded-2xl aspect-[4/3] mb-5">
-                  <img
-                    src={post.image}
-                    alt={post.title}
-                    className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
-                  />
-                </div>
-
-                {/* Meta */}
-                <div className="flex items-center gap-3 mb-3 font-system">
-                  <span className="text-xs font-bold uppercase tracking-widest text-femme-plum">
-                    {post.category}
-                  </span>
-                  <span className="text-femme-dark/30">·</span>
-                  <span className="text-xs text-femme-dark/50">{post.readTime}</span>
-                </div>
-
-                {/* Title */}
-                <h2 className="text-2xl text-femme-dark leading-snug mb-3 group-hover:text-femme-plum transition-colors duration-200">
-                  {post.title}
-                </h2>
-
-                {/* Excerpt */}
-                <p className="text-femme-dark/60 text-base leading-relaxed font-system line-clamp-3">
-                  {post.excerpt}
-                </p>
-
-                {/* Date */}
-                <p className="mt-4 text-xs text-femme-dark/40 font-system uppercase tracking-widest">
-                  {post.date}
-                </p>
-              </Link>
-            </motion.article>
+              {cat}
+            </button>
           ))}
         </div>
+
+        {/* Post grid */}
+        <AnimatePresence mode="wait">
+          {filtered.length > 0 ? (
+            <motion.div
+              key={activeCategory}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.25 }}
+              className="grid md:grid-cols-2 gap-x-12 gap-y-0"
+            >
+              {filtered.map((post, index) => (
+                <PostCard key={post.slug} post={post} index={index} />
+              ))}
+            </motion.div>
+          ) : (
+            <motion.p
+              key="empty"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="text-femme-dark/40 font-system py-16 text-center"
+            >
+              No posts in this category yet — check back soon.
+            </motion.p>
+          )}
+        </AnimatePresence>
       </section>
     </div>
   );

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,0 +1,133 @@
+import { useParams, Link, Navigate } from "react-router-dom";
+import { motion } from "motion/react";
+import { ArrowLeft } from "lucide-react";
+import { getPost } from "../data/posts";
+
+function renderBody(body: string) {
+  return body.split("\n\n").map((block, i) => {
+    if (block.startsWith("## ")) {
+      return (
+        <h2 key={i} className="text-3xl text-femme-dark mt-10 mb-4 italic">
+          {block.replace("## ", "")}
+        </h2>
+      );
+    }
+    if (block.startsWith("- ")) {
+      const items = block.split("\n").filter((l) => l.startsWith("- "));
+      return (
+        <ul key={i} className="flex flex-col gap-2 my-4 pl-2">
+          {items.map((item, j) => (
+            <li key={j} className="flex gap-3 items-start font-system text-femme-dark/80 text-lg leading-relaxed">
+              <span className="w-1.5 h-1.5 rounded-full bg-femme-plum shrink-0 mt-[10px]" />
+              {item.replace("- ", "")}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+    if (block === "---") {
+      return <hr key={i} className="border-femme-plum/15 my-10" />;
+    }
+    return (
+      <p key={i} className="text-femme-dark/80 text-lg leading-relaxed font-system">
+        {block}
+      </p>
+    );
+  });
+}
+
+export default function BlogPost() {
+  const { slug } = useParams<{ slug: string }>();
+  const post = getPost(slug ?? "");
+
+  if (!post) return <Navigate to="/journal" replace />;
+
+  return (
+    <div className="min-h-screen bg-femme-cream">
+      {/* Hero image */}
+      <div className="relative h-[55vh] w-full overflow-hidden">
+        <img
+          src={post.image}
+          alt={post.title}
+          className="w-full h-full object-cover object-center"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-femme-dark/70 via-femme-dark/20 to-transparent" />
+      </div>
+
+      {/* Article */}
+      <div className="max-w-3xl mx-auto px-6 md:px-0 pb-24">
+        {/* Back link */}
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+          className="pt-10 mb-8"
+        >
+          <Link
+            to="/journal"
+            className="inline-flex items-center gap-2 text-sm font-bold uppercase tracking-widest text-femme-plum hover:text-femme-dark transition-colors duration-200 font-system"
+          >
+            <ArrowLeft size={15} strokeWidth={2.5} />
+            Back to Journal
+          </Link>
+        </motion.div>
+
+        {/* Header */}
+        <motion.header
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.1, ease: "easeOut" }}
+          className="mb-12"
+        >
+          <div className="flex items-center gap-3 mb-5 font-system">
+            <span className="text-xs font-bold uppercase tracking-widest text-femme-plum">
+              {post.category}
+            </span>
+            <span className="text-femme-dark/30">·</span>
+            <span className="text-xs text-femme-dark/50">{post.readTime}</span>
+            <span className="text-femme-dark/30">·</span>
+            <span className="text-xs text-femme-dark/50">{post.date}</span>
+          </div>
+          <h1 className="text-5xl md:text-6xl text-femme-dark leading-tight italic mb-4">
+            {post.title}
+          </h1>
+          <p className="text-femme-dark/60 text-xl leading-relaxed font-system">
+            {post.excerpt}
+          </p>
+          <div className="h-px bg-femme-plum/15 mt-8" />
+        </motion.header>
+
+        {/* Body */}
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2, ease: "easeOut" }}
+          className="flex flex-col gap-5"
+        >
+          {renderBody(post.body)}
+        </motion.div>
+
+        {/* CTA */}
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.3, ease: "easeOut" }}
+          className="mt-16 bg-femme-pale rounded-2xl p-10 flex flex-col gap-4"
+        >
+          <p className="text-femme-dark text-2xl italic">
+            Ready to start planning?
+          </p>
+          <p className="text-femme-dark/60 text-base font-system">
+            We'd love to hear about your wedding. Fill out an inquiry and we'll be in touch within 48 hours.
+          </p>
+          <Link
+            to="/#inquiry"
+            className="inline-block bg-femme-plum text-white px-8 py-3.5 rounded-full font-bold text-sm uppercase tracking-widest font-system hover:bg-femme-dark transition-colors duration-200 w-fit mt-2"
+          >
+            Get in Touch
+          </Link>
+        </motion.div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #14

Builds out the full Blog / Journal section as a separate routed page, with an editorial aesthetic.

### Changes

- **Routing** — Added `react-router-dom` with `BrowserRouter`. Home page sections stay on `/`, journal at `/journal`, individual posts at `/journal/:slug`.
- **`src/App.tsx`** — Wrapped in `BrowserRouter`, inline `Home` component, three `Route` definitions.
- **`src/components/Navbar.tsx`** — Uses `useLocation` so non-home pages start with solid navbar. Anchor hrefs resolve correctly from any page (`/#about` vs `#about`). Added active Journal `NavLink`.
- **`src/pages/BlogIndex.tsx`** — Editorial journal index: featured post as a split-panel hero card, horizontal category filter bar (All / Planning / Services / Venues), 2-column post grid with `AnimatePresence` filtering, "Read Story →" links with gap animation on hover.
- **`src/pages/BlogPost.tsx`** — Full post view: hero image, back link, meta row, body renderer (`##` headings, `- ` bullets, `---` dividers, paragraphs), inquiry CTA at bottom.
- **`src/data/posts.ts`** — Three sample posts: *Six Months Out*, *Day-of Coordination Myths*, *Atlanta Wedding Venues*.

## Test Plan

- [ ] `/journal` loads — featured post, category filter, and post grid all render
- [ ] Category filter animates grid correctly, empty state shows when no posts
- [ ] "Read Story" routes to `/journal/:slug`, full post renders
- [ ] "Back to Journal" returns to `/journal`
- [ ] "Get in Touch" CTA routes to `/#inquiry`
- [ ] Journal NavLink highlights as active on `/journal` and `/journal/:slug`
- [ ] Non-home pages: navbar starts solid immediately
- [ ] Home anchor links (`/#about`, `/#services`, etc.) work from journal pages

🤖 Generated with [Claude Code](https://claude.ai/claude-code)