### PR TITLE
fix: Learn More button scrolls to Services (#7)

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -30,13 +30,14 @@ export default function About() {
         <p className="text-femme-dark/80 text-xl leading-relaxed max-w-lg">
           Look, anyone can book a ballroom. We zero in on the tiny moments—grandma's happy tears, the inside joke on the cocktail napkin, the playlist that makes cousins dance together on purpose.
         </p>
-        <motion.button
+        <motion.a
+          href="#services"
           whileHover={{ scale: 1.03, backgroundColor: "#3f0d2a" }}
           whileTap={{ scale: 0.97 }}
           className="bg-femme-plum text-white px-12 py-4 rounded-full font-medium text-base w-fit shadow-lg transition-colors duration-200 cursor-pointer"
         >
           Learn More
-        </motion.button>
+        </motion.a>
       </motion.div>
     </section>
   );


### PR DESCRIPTION
## Summary

Closes #7

The Learn More button in the About section was not functioning. It now scrolls the user to the Services section.

### Changes

- Updated `src/components/About.tsx` — wired the Learn More button's `href` to `#services`

## Test Plan

- [ ] Click "Learn More" in About section — page smooth-scrolls to Services
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)