### PR TITLE
Migrate hardcoded hex colors to femme-* token system

### DIFF
--- a/components/ui/button-shiny.tsx
+++ b/components/ui/button-shiny.tsx
@@ -18,28 +18,28 @@ function ButtonCta({ label = "Book a Consultation", className, ...props }: Butto
       {...props}
     >
       {/* Outer border gradient — plum → dark → plum */}
-      <div className="absolute inset-0 rounded-full p-[2px] bg-gradient-to-b from-[#bd708c] via-[#3f0d2a] to-[#7f165b]">
-        <div className="absolute inset-0 bg-[#3f0d2a] rounded-full opacity-90" />
+      <div className="absolute inset-0 rounded-full p-[2px] bg-gradient-to-b from-femme-sage via-femme-dark to-femme-plum">
+        <div className="absolute inset-0 bg-femme-dark rounded-full opacity-90" />
       </div>
 
       {/* Inner fill layers */}
-      <div className="absolute inset-[2px] bg-[#3f0d2a] rounded-full opacity-95" />
-      <div className="absolute inset-[2px] bg-gradient-to-r from-[#3f0d2a] via-[#5a1140] to-[#3f0d2a] rounded-full opacity-90" />
-      <div className="absolute inset-[2px] bg-gradient-to-b from-[#bd708c]/40 via-[#5a1140] to-[#7f165b]/30 rounded-full opacity-80" />
-      <div className="absolute inset-[2px] bg-gradient-to-br from-[#ddadbc]/10 via-[#5a1140] to-[#3f0d2a]/50 rounded-full" />
+      <div className="absolute inset-[2px] bg-femme-dark rounded-full opacity-95" />
+      <div className="absolute inset-[2px] bg-gradient-to-r from-femme-dark via-femme-plum to-femme-dark rounded-full opacity-90" />
+      <div className="absolute inset-[2px] bg-gradient-to-b from-femme-sage/40 via-femme-plum to-femme-plum/30 rounded-full opacity-80" />
+      <div className="absolute inset-[2px] bg-gradient-to-br from-femme-pink/10 via-femme-plum to-femme-dark/50 rounded-full" />
 
       {/* Inner glow */}
-      <div className="absolute inset-[2px] shadow-[inset_0_0_15px_rgba(189,112,140,0.2)] rounded-full" />
+      <div className="absolute inset-[2px] shadow-[inset_0_0_15px_rgba(197,109,153,0.2)] rounded-full" />
 
       {/* Label */}
       <div className="relative flex items-center justify-center gap-2">
-        <span className="text-base font-bold bg-gradient-to-b from-[#ddadbc] to-[#bd708c] bg-clip-text text-transparent drop-shadow-[0_0_12px_rgba(189,112,140,0.5)] tracking-widest uppercase font-system">
+        <span className="text-base font-bold bg-gradient-to-b from-femme-pink to-femme-sage bg-clip-text text-transparent drop-shadow-[0_0_12px_rgba(197,109,153,0.5)] tracking-widest uppercase font-system">
           {label}
         </span>
       </div>
 
       {/* Hover shimmer */}
-      <div className="absolute inset-[2px] opacity-0 transition-opacity duration-300 bg-gradient-to-r from-[#7f165b]/20 via-[#ddadbc]/10 to-[#7f165b]/20 group-hover:opacity-100 rounded-full" />
+      <div className="absolute inset-[2px] opacity-0 transition-opacity duration-300 bg-gradient-to-r from-femme-plum/20 via-femme-pink/10 to-femme-plum/20 group-hover:opacity-100 rounded-full" />
     </Button>
   )
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -32,7 +32,7 @@ export default function About() {
         </p>
         <motion.a
           href="#services"
-          whileHover={{ scale: 1.03, backgroundColor: "#570f38" }}
+          whileHover={{ scale: 1.03, backgroundColor: "var(--color-femme-deep)" }}
           whileTap={{ scale: 0.97 }}
           className="bg-femme-plum text-white px-12 py-4 rounded-full font-medium text-base w-fit shadow-lg transition-colors duration-200 cursor-pointer"
         >

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -41,11 +41,10 @@ export default function Hero() {
         >
           <motion.a
             href="#inquiry"
-            whileHover={{ scale: 1.05, backgroundColor: "#570f38", boxShadow: "0 8px 28px rgba(131,22,84,0.5)" }}
+            whileHover={{ scale: 1.05, backgroundColor: "var(--color-femme-deep)", boxShadow: "0 8px 28px rgba(131,22,84,0.5)" }}
             whileTap={{ scale: 0.97 }}
             transition={{ duration: 0.2, ease: "easeOut" }}
-            style={{ backgroundColor: "#831654" }}
-            className="inline-block text-white px-10 py-4 rounded-full font-bold text-sm uppercase tracking-widest shadow-lg font-system"
+            className="inline-block bg-femme-plum text-white px-10 py-4 rounded-full font-bold text-sm uppercase tracking-widest shadow-lg font-system"
           >
             Let's Chat
           </motion.a>

--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,7 @@
 
   /* 30% — Dark Raspberry: buttons, badges, accent lines, hover states */
   --color-femme-plum: #831654;     /* dark-raspberry-700 — primary buttons & badges */
+  --color-femme-deep: #570f38;     /* dark-raspberry-800 — button hover / pressed state */
   --color-femme-mauve: #ae1e70;    /* dark-raspberry-600 — hover states, secondary accents */
   --color-femme-orange: #e151a3;   /* dark-raspberry-400 — accent dividers & highlights */
 


### PR DESCRIPTION
## Summary

Cherry-picked color token migration from Claude Code's work on `fe/cd-color-token-migration`. This is a clean version that contains ONLY the color changes, without the unrelated Inquiry.tsx and .env.example changes from the original branch.

Closes #20

## Changes

- **`src/index.css`** — Added `--color-femme-deep` token (`#570f38`, dark-raspberry-800) for CTA button hover states
- **`src/components/Hero.tsx`** — Moved `#831654` from inline `style={}` to `bg-femme-plum` class; replaced `#570f38` hover hex with `var(--color-femme-deep)`
- **`src/components/About.tsx`** — Same `#570f38` → `var(--color-femme-deep)` fix in whileHover
- **`components/ui/button-shiny.tsx`** — Replaced all 11 deprecated hex values with `femme-*` Tailwind tokens

## Color Mapping

| Deprecated hex | New token | New value |
|---|---|---|
| `#3f0d2a` (old dark fill) | `femme-dark` | `#240f15` |
| `#5a1140` (old mid plum) | `femme-plum` | `#831654` |
| `#7f165b` (old deep plum) | `femme-plum` | `#831654` |
| `#bd708c` (old medium pink) | `femme-sage` | `#c56d99` |
| `#ddadbc` (old light pink) | `femme-pink` | `#d293a6` |
| `#570f38` (hover state) | `femme-deep` (new token) | `#570f38` |
| `#831654` (primary button) | `femme-plum` | `#831654` |

## Testing

- `npm run build` passes clean
- Zero hardcoded hex values remain in `src/` or `components/`
- Only 4 files changed (pure color migration, no unrelated changes)

## Note

Supersedes PR #36 which contained unrelated Inquiry.tsx changes on the same branch.