### PR TITLE
Make Book Now buttons link to inquiry form (#43)

### DIFF
--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -138,17 +138,19 @@ function ServiceCard({ service, index }: { service: typeof services[0]; index: n
           </p>
         </div>
 
-        {/* Book Now button */}
-        <motion.button
+        {/* Book Now button — links to inquiry section */}
+        <motion.a
+          href="#inquiry"
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
-          className="w-full py-3.5 text-sm font-bold uppercase tracking-widest font-system
+          aria-label={`Book ${service.title} — jump to inquiry form`}
+          className="block w-full py-3.5 text-sm font-bold uppercase tracking-widest font-system text-center
             bg-transparent border-2 border-white/70 text-white
             hover:bg-femme-plum hover:border-femme-plum
-            transition-colors duration-200 cursor-pointer rounded-sm"
+            transition-colors duration-200 cursor-pointer rounded-sm no-underline"
         >
           Book Now
-        </motion.button>
+        </motion.a>
       </div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- Converts the inert `<motion.button>` on each ServiceCard to a `<motion.a href="#inquiry">` so all three Book Now buttons jump to the inquiry section
- Smooth scroll is already enabled globally (`src/index.css:59`), so the jump animates by default
- Preserves existing hover/tap motion props and button styling exactly
- Adds an `aria-label` noting the source service tier for screen readers

## Scope note
The issue recommends starting with Option A (anchor-only) and treating service pre-fill as a follow-up. This PR keeps that minimal scope — pre-filling the inquiry form with the selected tier should be its own ticket against `Inquiry.tsx`.

## Test plan
- [ ] Click Book Now on each of the three service cards → page scrolls smoothly to inquiry form
- [ ] Hover/tap motion still feels identical to before
- [ ] Keyboard: tab to button, press Enter → same behavior as click
- [ ] Screen reader announces destination (aria-label includes service tier)
- [ ] Mobile viewport: scroll target lands inquiry section in view

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)