### PR TITLE
[Mobile #3/4] Image loading attributes (lazy/decoding/fetchpriority)

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -13,6 +13,8 @@ export default function About() {
         <img
           src="/photos/pt2.jpg"
           alt="Bridal detail flat lay with shoes, invitation and rings"
+          loading="lazy"
+          decoding="async"
           className="w-full h-auto object-contain shadow-2xl"
         />
       </motion.div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,6 +6,8 @@ export default function Footer() {
           <img
             src="/logo-footer.svg"
             alt="Femme Events"
+            loading="lazy"
+            decoding="async"
             className="h-24 w-auto object-contain object-left"
           />
           <p className="text-sm opacity-60 font-system">Made with love in Atlanta.</p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -8,6 +8,8 @@ export default function Hero() {
         <img
           src="/hero-background.svg"
           alt="Femme Events hero background"
+          fetchPriority="high"
+          decoding="async"
           className="w-full h-full object-cover object-center"
         />
         {/* Stronger bottom gradient so info bar is always legible */}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -104,6 +104,7 @@ export default function Navbar() {
           <img
             src="/logo-nav.svg"
             alt="Femme Events"
+            decoding="async"
             className="h-8 w-auto transition-all duration-300"
             style={scrolled || menuOpen ? {} : { filter: "brightness(0) invert(1)" }}
           />

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -76,6 +76,8 @@ function ServiceCard({ service, index }: { service: typeof services[0]; index: n
       <motion.img
         src={service.image}
         alt={service.alt}
+        loading="lazy"
+        decoding="async"
         className="absolute inset-0 w-full h-full object-cover object-center"
         animate={{ scale: hovered ? 1.06 : 1 }}
         transition={{ duration: 0.6, ease: "easeOut" }}

--- a/src/pages/BlogIndex.tsx
+++ b/src/pages/BlogIndex.tsx
@@ -19,6 +19,8 @@ function FeaturedPost({ post }: { post: Post }) {
         <img
           src={post.image}
           alt={post.title}
+          fetchPriority="high"
+          decoding="async"
           className="w-full h-full object-cover"
         />
       </div>
@@ -66,6 +68,8 @@ function PostCard({ post, index }: { post: Post; index: number }) {
         <img
           src={post.image}
           alt={post.title}
+          loading="lazy"
+          decoding="async"
           className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
         />
       </div>

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -49,6 +49,8 @@ export default function BlogPost() {
         <img
           src={post.image}
           alt={post.title}
+          fetchPriority="high"
+          decoding="async"
           className="w-full h-full object-cover object-center"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-femme-dark/70 via-femme-dark/20 to-transparent" />


### PR DESCRIPTION
## Summary

Slice 3/4 of mobile experience initiative (#42). Attribute-only changes to give the browser better hints about how to load images — no asset transcoding or markup restructuring.

- Above-fold critical images: \`fetchPriority=\"high\"\` + \`decoding=\"async\"\`
  - Hero background (Hero.tsx)
  - Journal featured post image (BlogIndex.tsx)
  - Individual BlogPost hero (BlogPost.tsx)
- Below-fold images: \`loading=\"lazy\"\` + \`decoding=\"async\"\`
  - About photo (About.tsx)
  - Services cards / motion.img (Services.tsx)
  - Footer logo (Footer.tsx)
  - Journal post cards (BlogIndex.tsx)
- Navbar logo: \`decoding=\"async\"\` only — above-fold but a small SVG, lazy not appropriate

7 files, 15 lines added, 0 removed.

## Why attribute-only

The biggest perf wins (WebP, srcset, binary compression) require \`vite-imagetools\` and an asset regeneration pipeline. That's deferred to a separate follow-up issue so this slice can land cleanly without dragging in build-config changes.

Image inventory at audit time:
- hero-background.svg: 11 MB (embeds base64 JPEG — main offender)
- pt2.jpg: 3.8 MB, pt3.jpg: 4.3 MB, kj1.jpg: 2.0 MB, kj2.jpg: 2.3 MB
- logo-footer.svg: 452 KB

These attribute changes alone won't shrink the bytes — they'll just stop the browser from blocking on below-fold work, and tell the network layer to prioritize the hero correctly.

## Test plan

- [ ] DevTools Network: confirm hero image loads with high priority on initial paint
- [ ] DevTools Network: confirm About/Services/Footer images defer until scrolled into view
- [ ] No console warnings about \`fetchpriority\` casing (using camelCase \`fetchPriority\` for React 19)
- [ ] Visual regression: nothing looks different — these are HTML hints, not style changes

Closes #51
Refs #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)