### PR TITLE
[Mobile #4/4] Performance hints + PWA meta (route splitting, font preload, theme-color)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,20 @@
     <meta name="description" content="Femme Events is an Atlanta-based wedding coordination and design studio offering day-of coordination, partial planning, and full design packages. Serving Atlanta, GA and surrounding areas." />
     <link rel="canonical" href="https://femmeevents.com/" />
 
+    <!-- Mobile / PWA -->
+    <meta name="theme-color" content="#831654" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Femme Events" />
+
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/logo-nav.svg" />
+
+    <!-- Preload above-the-fold display fonts. The Seasons (body) is omitted —
+         font-display: swap already covers it with system fallbacks. -->
+    <link rel="preload" href="/fonts/frunchy-sage.ttf" as="font" type="font/ttf" crossorigin />
+    <link rel="preload" href="/fonts/balgin-display-regular.otf" as="font" type="font/otf" crossorigin />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Suspense, lazy } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Navbar from "./components/Navbar";
 import Footer from "./components/Footer";
@@ -14,8 +15,11 @@ import Testimonials from "./components/Testimonials";
 import Vendors from "./components/Vendors";
 import FAQ from "./components/FAQ";
 import Inquiry from "./components/Inquiry";
-import BlogIndex from "./pages/BlogIndex";
-import BlogPost from "./pages/BlogPost";
+
+// Journal routes are split out so homepage visitors don't pay to download
+// blog code on first load.
+const BlogIndex = lazy(() => import("./pages/BlogIndex"));
+const BlogPost = lazy(() => import("./pages/BlogPost"));
 
 function Home() {
   return (
@@ -36,11 +40,13 @@ export default function App() {
   return (
     <BrowserRouter>
       <Navbar />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/journal" element={<BlogIndex />} />
-        <Route path="/journal/:slug" element={<BlogPost />} />
-      </Routes>
+      <Suspense fallback={<div className="min-h-screen bg-femme-cream" />}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/journal" element={<BlogIndex />} />
+          <Route path="/journal/:slug" element={<BlogPost />} />
+        </Routes>
+      </Suspense>
       <Footer />
     </BrowserRouter>
   );


### PR DESCRIPTION
## Summary

Slice 4/4 of the mobile experience initiative (#42). Performance hints and mobile-app-style meta tags — no visual changes.

- **Route splitting**: \`/journal\` and \`/journal/:slug\` are now \`React.lazy\` + \`Suspense\` so homepage visitors don't pay to download blog code on first load. Build output confirms the split:

  | Chunk | Size | Gzip |
  |---|---|---|
  | \`BlogIndex-*.js\` | 5.26 KB | 1.63 KB |
  | \`BlogPost-*.js\` | 3.78 KB | 1.45 KB |
  | \`posts-*.js\` (shared data) | 7.43 KB | 3.35 KB |
  | \`index-*.js\` (main) | 402.62 KB | 127.07 KB |

  Roughly 6.4 KB gzipped saved off the homepage critical path. Suspense fallback is an empty cream-background div sized to viewport so users never see a flash of white during the route fetch.

- **Font preload**: Frunchy Sage (h1/h2 — biggest above-fold element) and Balgin (h3/h4 + hero subhead) get \`<link rel=\"preload\">\`. The Seasons (body font) is omitted on purpose — \`font-display: swap\` already covers it with system fallbacks during load, and preloading three fonts would compete with the hero image for bandwidth.

- **PWA / mobile meta** in \`index.html\`:
  - \`theme-color\` → \`#831654\` (femme-plum) — Android/Chrome address bar matches brand.
  - \`apple-mobile-web-app-capable\` + \`mobile-web-app-capable\` — installability.
  - \`apple-mobile-web-app-status-bar-style\` — iOS status bar blends with the dark hero.
  - \`apple-mobile-web-app-title\` — home-screen install reads \"Femme Events\".

## Out of scope (explicit)

- WebP / srcset / binary image compression — needs \`vite-imagetools\` and an asset regeneration pipeline. Track separately as a follow-up to slice 3.
- Bundle audit / dependency tree-shaking — main bundle is still 402 KB raw / 127 KB gzipped, dominated by motion + react-router + lucide. Worth a dedicated investigation, not part of an attribute-only slice.
- Service worker / full PWA manifest — a separate concern from the meta tags.
- Lighthouse target verification (>=90 from #42 acceptance) — slice 4 lays groundwork; verification belongs in a dedicated audit issue once images are also optimized.

## Test plan

- [ ] Homepage loads — verify journal chunk does NOT appear in DevTools Network on first visit
- [ ] Visit /journal — verify journal chunk loads on demand, no flash of white between routes
- [ ] DevTools → Application → Manifest area: confirm theme-color and PWA meta picked up
- [ ] Mobile Safari: \"Add to Home Screen\" shows \"Femme Events\" with branded status bar
- [ ] Network tab: confirm Frunchy Sage and Balgin load early in the waterfall, not late

Typecheck clean apart from the pre-existing \`Inquiry.tsx\` \`import.meta.env\` error.

Closes #56
Refs #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)