### PR TITLE
Sanity data layer + studio scaffold for journal (PR A of #21)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,11 @@
 # Create a form at https://formspree.io and paste the endpoint URL below
 # Format: https://formspree.io/f/{your-form-id}
 VITE_FORMSPREE_ENDPOINT=
+
+# Sanity CMS (journal/blog backend — see issue #21)
+# Leave VITE_SANITY_PROJECT_ID unset to fall back to the static posts in
+# src/data/posts.ts. Once the Sanity project exists, paste its ID here
+# and in Vercel env vars.
+VITE_SANITY_PROJECT_ID=
+VITE_SANITY_DATASET=production
+VITE_SANITY_API_VERSION=2024-01-01

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/genai": "^1.29.0",
         "@radix-ui/react-slot": "^1.2.4",
+        "@sanity/client": "^7.22.0",
         "@tailwindcss/vite": "^4.1.14",
         "@vitejs/plugin-react": "^5.0.4",
         "class-variance-authority": "^0.7.1",
@@ -20,8 +21,8 @@
         "motion": "^12.23.24",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.5.0",
         "react-router-dom": "^7.14.1",
+        "tailwind-merge": "^3.5.0",
         "vite": "^6.2.0"
       },
       "devDependencies": {
@@ -1250,6 +1251,33 @@
         "win32"
       ]
     },
+    "node_modules/@sanity/client": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.0.tgz",
+      "integrity": "sha512-KqN9cowZwfZNCwCchRaz1B9WrZTThQxX/gfJhJO1uKJBuk/JcbYGBiSK9CSqocWoYDQ/QqANVXy1r7a8zognww==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.7.2",
+        "nanoid": "^3.3.11",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@sanity/eventsource": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.2.tgz",
+      "integrity": "sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/event-source-polyfill": "1.0.5",
+        "@types/eventsource": "1.1.15",
+        "event-source-polyfill": "1.0.31",
+        "eventsource": "2.0.2"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1585,6 +1613,18 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/event-source-polyfill": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz",
+      "integrity": "sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/eventsource": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
+      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==",
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -2067,6 +2107,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
+      "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2258,6 +2313,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
+      "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -2555,6 +2625,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-it": {
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.7.2.tgz",
+      "integrity": "sha512-slSwC/BBAnoz9OnHopU+V5pJKAieddoF6dmx2CvbWMRePgup8ftiB+D7d+pr2PZzcqNtZOVDMoLOsXGsERhTEg==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^7.0.0",
+        "is-retry-allowed": "^2.2.0",
+        "through2": "^4.0.2",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -2707,6 +2792,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jiti": {
@@ -3141,6 +3238,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/motion": {
       "version": "12.38.0",
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
@@ -3521,6 +3630,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3582,6 +3705,15 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.1",
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -3781,6 +3913,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
@@ -3808,6 +3949,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/tinyglobby": {
@@ -3859,6 +4009,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -3932,6 +4094,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@google/genai": "^1.29.0",
     "@radix-ui/react-slot": "^1.2.4",
+    "@sanity/client": "^7.22.0",
     "@tailwindcss/vite": "^4.1.14",
     "@vitejs/plugin-react": "^5.0.4",
     "class-variance-authority": "^0.7.1",

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,60 @@
+import { sanityClient } from "./sanity";
+import { posts as fallbackPosts, type Post } from "../data/posts";
+
+export type { Post };
+
+const POSTS_QUERY = `*[_type == "post"] | order(date desc){
+  "slug": slug.current,
+  title,
+  excerpt,
+  category,
+  date,
+  readTime,
+  "image": image.asset->url,
+  body
+}`;
+
+const POST_QUERY = `*[_type == "post" && slug.current == $slug][0]{
+  "slug": slug.current,
+  title,
+  excerpt,
+  category,
+  date,
+  readTime,
+  "image": image.asset->url,
+  body
+}`;
+
+// Sync helpers for the initial render: when Sanity is disabled we resolve
+// from the static fallback immediately, preserving today's no-flash UX.
+// When Sanity is enabled, the initial render returns the "still loading"
+// shape and the async fetch fills in.
+
+export function getInitialPosts(): Post[] | null {
+  return sanityClient ? null : fallbackPosts;
+}
+
+export function getInitialPost(slug: string): Post | null | undefined {
+  if (sanityClient) return undefined;
+  return fallbackPosts.find((p) => p.slug === slug) ?? null;
+}
+
+export async function getPosts(): Promise<Post[]> {
+  if (!sanityClient) return fallbackPosts;
+  try {
+    return await sanityClient.fetch<Post[]>(POSTS_QUERY);
+  } catch {
+    return fallbackPosts;
+  }
+}
+
+export async function getPost(slug: string): Promise<Post | null> {
+  if (!sanityClient) {
+    return fallbackPosts.find((p) => p.slug === slug) ?? null;
+  }
+  try {
+    return await sanityClient.fetch<Post | null>(POST_QUERY, { slug });
+  } catch {
+    return fallbackPosts.find((p) => p.slug === slug) ?? null;
+  }
+}

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -1,0 +1,12 @@
+import { createClient, type SanityClient } from "@sanity/client";
+
+const projectId = import.meta.env.VITE_SANITY_PROJECT_ID;
+const dataset = import.meta.env.VITE_SANITY_DATASET ?? "production";
+const apiVersion = import.meta.env.VITE_SANITY_API_VERSION ?? "2024-01-01";
+
+// When VITE_SANITY_PROJECT_ID is unset (dev / preview deploys without CMS
+// wiring) the client is null and the data layer falls back to the static
+// posts in src/data/posts.ts. PR B will populate this in Vercel.
+export const sanityClient: SanityClient | null = projectId
+  ? createClient({ projectId, dataset, apiVersion, useCdn: true })
+  : null;

--- a/src/pages/BlogIndex.tsx
+++ b/src/pages/BlogIndex.tsx
@@ -1,10 +1,8 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "motion/react";
 import { ArrowRight } from "lucide-react";
-import { posts, type Post } from "../data/posts";
-
-const categories = ["All", ...Array.from(new Set(posts.map((p) => p.category)))];
+import { getInitialPosts, getPosts, type Post } from "../lib/posts";
 
 function FeaturedPost({ post }: { post: Post }) {
   return (
@@ -108,6 +106,33 @@ function PostCard({ post, index }: { post: Post; index: number }) {
 
 export default function BlogIndex() {
   const [activeCategory, setActiveCategory] = useState("All");
+  const [posts, setPosts] = useState<Post[] | null>(getInitialPosts);
+
+  useEffect(() => {
+    let cancelled = false;
+    getPosts().then((data) => {
+      if (!cancelled) setPosts(data);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const categories = useMemo(
+    () =>
+      posts
+        ? ["All", ...Array.from(new Set(posts.map((p) => p.category)))]
+        : ["All"],
+    [posts],
+  );
+
+  if (!posts || posts.length === 0) {
+    return (
+      <div className="min-h-screen bg-femme-cream pt-40 px-6 md:px-24">
+        <p className="text-femme-dark/40 font-system">Loading the journal…</p>
+      </div>
+    );
+  }
 
   const featured = posts[0];
   const rest = posts.slice(1);

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,7 +1,8 @@
+import { useEffect, useState } from "react";
 import { useParams, Link, Navigate } from "react-router-dom";
 import { motion } from "motion/react";
 import { ArrowLeft } from "lucide-react";
-import { getPost } from "../data/posts";
+import { getInitialPost, getPost, type Post } from "../lib/posts";
 
 function renderBody(body: string) {
   return body.split("\n\n").map((block, i) => {
@@ -38,9 +39,24 @@ function renderBody(body: string) {
 
 export default function BlogPost() {
   const { slug } = useParams<{ slug: string }>();
-  const post = getPost(slug ?? "");
+  // undefined = still loading (Sanity path); null = loaded, not found.
+  const [post, setPost] = useState<Post | null | undefined>(() =>
+    slug ? getInitialPost(slug) : null,
+  );
 
-  if (!post) return <Navigate to="/journal" replace />;
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+    getPost(slug).then((data) => {
+      if (!cancelled) setPost(data);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  if (post === undefined) return null;
+  if (post === null) return <Navigate to="/journal" replace />;
 
   return (
     <div className="min-h-screen bg-femme-cream">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_FORMSPREE_ENDPOINT?: string;
+  readonly VITE_SANITY_PROJECT_ID?: string;
+  readonly VITE_SANITY_DATASET?: string;
+  readonly VITE_SANITY_API_VERSION?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/studio/.gitignore
+++ b/studio/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.sanity/
+dist/
+.env
+.env.local

--- a/studio/package.json
+++ b/studio/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "femme-events-studio",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Sanity Studio for the Femme Events journal. Deployed separately to femmeevents.sanity.studio.",
+  "scripts": {
+    "dev": "sanity dev",
+    "start": "sanity start",
+    "build": "sanity build",
+    "deploy": "sanity deploy"
+  },
+  "dependencies": {
+    "@sanity/vision": "^3.50.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "sanity": "^3.50.0",
+    "styled-components": "^6.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/studio/sanity.cli.ts
+++ b/studio/sanity.cli.ts
@@ -1,0 +1,8 @@
+import { defineCliConfig } from "sanity/cli";
+
+export default defineCliConfig({
+  api: {
+    projectId: process.env.SANITY_STUDIO_PROJECT_ID,
+    dataset: process.env.SANITY_STUDIO_DATASET ?? "production",
+  },
+});

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "sanity";
+import { structureTool } from "sanity/structure";
+import { visionTool } from "@sanity/vision";
+import { schemaTypes } from "./schemas";
+
+const projectId =
+  process.env.SANITY_STUDIO_PROJECT_ID ?? "REPLACE_WITH_PROJECT_ID";
+const dataset = process.env.SANITY_STUDIO_DATASET ?? "production";
+
+export default defineConfig({
+  name: "femme-events-studio",
+  title: "Femme Events Journal",
+  projectId,
+  dataset,
+  plugins: [structureTool(), visionTool()],
+  schema: { types: schemaTypes },
+});

--- a/studio/schemas/index.ts
+++ b/studio/schemas/index.ts
@@ -1,0 +1,3 @@
+import { post } from "./post";
+
+export const schemaTypes = [post];

--- a/studio/schemas/post.ts
+++ b/studio/schemas/post.ts
@@ -1,0 +1,73 @@
+import { defineField, defineType } from "sanity";
+
+export const post = defineType({
+  name: "post",
+  title: "Journal Post",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "slug",
+      title: "Slug",
+      type: "slug",
+      options: { source: "title", maxLength: 96 },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "excerpt",
+      title: "Excerpt",
+      type: "text",
+      rows: 3,
+      description: "Short summary shown on the journal index card.",
+      validation: (Rule) => Rule.required().max(280),
+    }),
+    defineField({
+      name: "category",
+      title: "Category",
+      type: "string",
+      options: {
+        list: [
+          { title: "Planning", value: "Planning" },
+          { title: "Real Weddings", value: "Real Weddings" },
+          { title: "Vendors", value: "Vendors" },
+          { title: "Inspiration", value: "Inspiration" },
+        ],
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "date",
+      title: "Publish Date",
+      type: "date",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "readTime",
+      title: "Read Time",
+      type: "string",
+      description: 'e.g. "5 min read"',
+    }),
+    defineField({
+      name: "image",
+      title: "Cover Image",
+      type: "image",
+      options: { hotspot: true },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "body",
+      title: "Body",
+      type: "array",
+      of: [{ type: "block" }],
+      description: "Rich text body of the post.",
+    }),
+  ],
+  preview: {
+    select: { title: "title", media: "image", subtitle: "category" },
+  },
+});

--- a/studio/tsconfig.json
+++ b/studio/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,7 @@
     },
     "allowImportingTsExtensions": true,
     "noEmit": true
-  }
+  },
+  "include": ["src", "vite.config.*"],
+  "exclude": ["node_modules", "dist", "studio"]
 }


### PR DESCRIPTION
## Summary

PR A of two for issue #21. **Code-only foundation** for moving the journal off hardcoded posts and onto Sanity. No external account, no studio deploy, no env secrets — those land in PR B. The site behaves identically today.

### Frontend
- \`@sanity/client\` added to dependencies.
- \`src/lib/sanity.ts\` — creates the Sanity client only when \`VITE_SANITY_PROJECT_ID\` is set; exports \`null\` otherwise. The data layer keys off this null check.
- \`src/lib/posts.ts\` — typed data layer:
  - **Sync helpers** (\`getInitialPosts\` / \`getInitialPost\`) for first-render: when Sanity is disabled they resolve from the static fallback immediately so there's no loading flash, preserving today's UX exactly. When Sanity is enabled they return the \"still loading\" shape and the async path fills in.
  - **Async fetchers** (\`getPosts\` / \`getPost\`) try Sanity, fall back to \`src/data/posts.ts\` on missing creds or network error.
- \`BlogIndex\` and \`BlogPost\` refactored to read through the new layer. Direct imports of \`src/data/posts\` are gone from the pages.
- \`src/vite-env.d.ts\` — typed \`import.meta.env\`. Side benefit: fixes the long-standing \`Inquiry.tsx\` \`VITE_FORMSPREE_ENDPOINT\` TS error.
- \`.env.example\` documents the three new vars (\`VITE_SANITY_PROJECT_ID\`, \`VITE_SANITY_DATASET\` defaulting to \`production\`, \`VITE_SANITY_API_VERSION\` defaulting to \`2024-01-01\`).
- Root \`tsconfig.json\` gains \`include\`/\`exclude\` so the studio package isn't dragged into website typecheck (it has its own deps).

### Studio (separate package, not deployed)
- \`studio/\` is a standalone package with its own \`package.json\`, \`tsconfig.json\`, \`.gitignore\`. **\`npm install\` is intentionally not run** — PR B owns that.
- \`studio/sanity.config.ts\` — schema wired up; \`projectId\` reads from \`SANITY_STUDIO_PROJECT_ID\` env var with a clear placeholder.
- \`studio/schemas/post.ts\` — \`title\`, \`slug\`, \`excerpt\`, \`category\` (enum), \`date\`, \`readTime\`, \`image\` (with hotspot), \`body\` (Portable Text).

## Why this split

Per the architectural decision: the studio is a separate package that will deploy to \`femmeevents.sanity.studio\`, not embedded at \`/studio\`. This keeps Sanity Studio's weight off the public website bundle entirely.

## Verification

- \`npx tsc --noEmit\` — clean (zero errors, including pre-existing).
- \`npx vite build\` — clean. Journal chunks gain only ~1KB total for the Sanity client (well tree-shaken thanks to the lazy \`/journal\` route from #56).
- Site renders identically with \`VITE_SANITY_PROJECT_ID\` unset (the only state that exists today).

## Out of scope (PR B)

- Create the Sanity project under Karan's account.
- \`npm install\` inside \`studio/\` and \`sanity deploy\` to \`femmeevents.sanity.studio\`.
- Add \`VITE_SANITY_PROJECT_ID\` + dataset to Vercel env vars.
- Port the 3 sample posts into Sanity.
- **Important — needs follow-up in PR B:** \`renderBody\` in \`BlogPost.tsx\` currently parses a markdown-ish string. Sanity's \`body\` field is Portable Text (an array of blocks), so PR B will need to add \`@portabletext/react\` and swap \`renderBody\` for a PT renderer (or serialize PT → string in the GROQ projection). Flagged here so it doesn't get lost.

## Test plan

- [ ] Pull this branch, run \`npm install\`, then \`npm run dev\` — \`/journal\` and \`/journal/:slug\` look and behave exactly like main.
- [ ] No console errors. No loading flash on \`/journal\` since the sync fallback resolves on first render.
- [ ] Deep-link to \`/journal/six-months-out-what-to-do-first\` resolves.
- [ ] Deep-link to a non-existent slug like \`/journal/nope\` redirects to \`/journal\`.
- [ ] \`npm run lint\` (which is \`tsc --noEmit\`) is clean.

Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)