### PR TITLE
Portable Text renderer + schema fixes (Refs #21)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "^1.29.0",
+        "@portabletext/react": "^6.0.3",
         "@radix-ui/react-slot": "^1.2.4",
         "@sanity/client": "^7.22.0",
         "@tailwindcss/vite": "^4.1.14",
@@ -782,6 +783,43 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@portabletext/react": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-6.0.3.tgz",
+      "integrity": "sha512-xkpykEYKdyR8DJq1oTGKhmwQMqIta8OEHAEMq1EQ5kGOdnVU4ZzU6c+1EZNgyNFpSZs/25ee3kA4Te9ybbQCyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/toolkit": "^5.0.2",
+        "@portabletext/types": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "react": "^18.2 || ^19"
+      }
+    },
+    "node_modules/@portabletext/toolkit": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-5.0.2.tgz",
+      "integrity": "sha512-Njc1LE1PMJkTx/wEPqZ6sOWGgFgX2B47fxpOQ/Ia4ByhsZoA5Sq8dNvvV5F052j/xE8TbOLiBEjS848FkKADDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/types": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      }
+    },
+    "node_modules/@portabletext/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-djfIGU9n6DRrunlvj2nIDAp17URo/nA4jSXGvf+Gupx8NLLy9fmJBZ3GL8yhqn9lSVc+cKCharjOa3aOBnWbRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
       }
     },
     "node_modules/@protobufjs/aspromise": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.29.0",
+    "@portabletext/react": "^6.0.3",
     "@radix-ui/react-slot": "^1.2.4",
     "@sanity/client": "^7.22.0",
     "@tailwindcss/vite": "^4.1.14",

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,7 +1,13 @@
+import type { PortableTextBlock } from "@portabletext/react";
 import { sanityClient } from "./sanity";
-import { posts as fallbackPosts, type Post } from "../data/posts";
+import { posts as fallbackPosts, type Post as FallbackPost } from "../data/posts";
 
-export type { Post };
+// Wider runtime type than the static fallback — Sanity returns Portable
+// Text blocks for `body`, the static posts use a markdown-ish string.
+// Both are renderable by BlogPost.tsx; the renderer branches on shape.
+export interface Post extends Omit<FallbackPost, "body"> {
+  body: string | PortableTextBlock[];
+}
 
 const POSTS_QUERY = `*[_type == "post"] | order(date desc){
   "slug": slug.current,

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -2,9 +2,50 @@ import { useEffect, useState } from "react";
 import { useParams, Link, Navigate } from "react-router-dom";
 import { motion } from "motion/react";
 import { ArrowLeft } from "lucide-react";
+import { PortableText, type PortableTextComponents } from "@portabletext/react";
 import { getInitialPost, getPost, type Post } from "../lib/posts";
 
-function renderBody(body: string) {
+// Custom serializers so Portable Text output matches the visual style of
+// the existing markdown-ish renderer (italic h2, plum-dot bullets, etc.).
+const portableTextComponents: PortableTextComponents = {
+  block: {
+    h2: ({ children }) => (
+      <h2 className="text-3xl text-femme-dark mt-10 mb-4 italic">{children}</h2>
+    ),
+    normal: ({ children }) => (
+      <p className="text-femme-dark/80 text-lg leading-relaxed font-system">
+        {children}
+      </p>
+    ),
+  },
+  list: {
+    bullet: ({ children }) => (
+      <ul className="flex flex-col gap-2 my-4 pl-2">{children}</ul>
+    ),
+  },
+  listItem: {
+    bullet: ({ children }) => (
+      <li className="flex gap-3 items-start font-system text-femme-dark/80 text-lg leading-relaxed">
+        <span className="w-1.5 h-1.5 rounded-full bg-femme-plum shrink-0 mt-[10px]" />
+        <span>{children}</span>
+      </li>
+    ),
+  },
+  marks: {
+    link: ({ value, children }) => (
+      <a
+        href={value?.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-femme-plum hover:opacity-70 transition-opacity"
+      >
+        {children}
+      </a>
+    ),
+  },
+};
+
+function renderMarkdownBody(body: string) {
   return body.split("\n\n").map((block, i) => {
     if (block.startsWith("## ")) {
       return (
@@ -35,6 +76,11 @@ function renderBody(body: string) {
       </p>
     );
   });
+}
+
+function renderBody(body: Post["body"]) {
+  if (typeof body === "string") return renderMarkdownBody(body);
+  return <PortableText value={body} components={portableTextComponents} />;
 }
 
 export default function BlogPost() {

--- a/studio/schemas/post.ts
+++ b/studio/schemas/post.ts
@@ -33,6 +33,8 @@ export const post = defineType({
       options: {
         list: [
           { title: "Planning", value: "Planning" },
+          { title: "Venues", value: "Venues" },
+          { title: "Services", value: "Services" },
           { title: "Real Weddings", value: "Real Weddings" },
           { title: "Vendors", value: "Vendors" },
           { title: "Inspiration", value: "Inspiration" },
@@ -51,6 +53,7 @@ export const post = defineType({
       title: "Read Time",
       type: "string",
       description: 'e.g. "5 min read"',
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       name: "image",
@@ -65,6 +68,7 @@ export const post = defineType({
       type: "array",
       of: [{ type: "block" }],
       description: "Rich text body of the post.",
+      validation: (Rule) => Rule.required().min(1),
     }),
   ],
   preview: {


### PR DESCRIPTION
Refs #21. Stacked on top of #58 — review/merge that one first.

Addresses Hermes's three non-blocking notes from the #58 review:

## Changes

**1. Portable Text renderer**
- Added `@portabletext/react` (^6.0.3)
- `BlogPost.tsx` now branches by body shape: string → existing markdown-ish renderer (used by `src/data/posts.ts` fallback); `PortableTextBlock[]` → `<PortableText>` with custom serializers
- Serializers match today's visual style: italic h2, plum-dot bullets, plum links opening in new tab
- `src/lib/posts.ts` widens `Post.body` to `string | PortableTextBlock[]` via interface extension (no mutation of the static fallback type)

**2. Schema categories**
- Added `Venues` and `Services` to the category enum in `studio/schemas/post.ts` so Amanda can tag posts with all categories already shown on the site

**3. Required-field validation**
- `body`: `Rule.required().min(1)` — can't publish an empty post
- `readTime`: `Rule.required()` — index card meta always renders

## Verification

- `npx tsc --noEmit` clean
- `npx vite build` clean (BlogPost chunk +~3KB gzipped from PortableText)
- String fallback path preserved — current journal still renders identically when Sanity is disabled

## Out of scope (PR B2)

Sanity project creation, studio deploy, Vercel env vars, and porting the 3 sample posts — these need account access and are blocked on Karan/Amanda. Will follow up once #58 + this are merged.