### PR TITLE
Testimonials backed by Sanity CMS (#32)

### DIFF
--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -1,5 +1,12 @@
+import { useEffect, useState } from "react";
 import { motion } from "motion/react";
 import { ArrowRight } from "lucide-react";
+import {
+  getInitialTestimonials,
+  getTestimonials,
+  type Testimonial,
+} from "../lib/testimonials";
+import { testimonials as fallbackTestimonials } from "../data/testimonials";
 
 function Name({ children }: { children: string }) {
   const parts = children.split("&");
@@ -17,28 +24,21 @@ function Name({ children }: { children: string }) {
   );
 }
 
-const testimonials = [
-  {
-    quote:
-      "Amanda made our day feel effortless. Every tiny detail we obsessed over for months just appeared — perfectly. We didn't lift a finger and somehow it was better than anything we'd imagined.",
-    name: "Priscila & Tri",
-    detail: "Atlanta, GA · Full Coordination + Design",
-  },
-  {
-    quote:
-      "Hiring Femme Events for day-of coordination was the best decision we made. Amanda kept everything moving without us ever feeling the pressure. Our guests still talk about how smooth it all was.",
-    name: "Kaitlyn & James",
-    detail: "Roswell, GA · Day-of Coordination",
-  },
-  {
-    quote:
-      "We were DIY-ing everything and totally overwhelmed. The partial planning package was exactly what we needed — vendor recommendations, mood boards, budget help. She got us across the finish line with our sanity intact.",
-    name: "Maya & Devon",
-    detail: "Decatur, GA · Partial Planning",
-  },
-];
-
 export default function Testimonials() {
+  const [testimonials, setTestimonials] = useState<Testimonial[]>(
+    () => getInitialTestimonials() ?? fallbackTestimonials,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    getTestimonials().then((data) => {
+      if (!cancelled && data.length > 0) setTestimonials(data);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <section className="py-16 md:py-24 px-6 md:px-24 bg-femme-pale">
       {/* Header row with arrow */}

--- a/src/data/testimonials.ts
+++ b/src/data/testimonials.ts
@@ -1,0 +1,26 @@
+export interface Testimonial {
+  quote: string;
+  name: string;
+  detail: string;
+}
+
+export const testimonials: Testimonial[] = [
+  {
+    quote:
+      "Amanda made our day feel effortless. Every tiny detail we obsessed over for months just appeared — perfectly. We didn't lift a finger and somehow it was better than anything we'd imagined.",
+    name: "Priscila & Tri",
+    detail: "Atlanta, GA · Full Coordination + Design",
+  },
+  {
+    quote:
+      "Hiring Femme Events for day-of coordination was the best decision we made. Amanda kept everything moving without us ever feeling the pressure. Our guests still talk about how smooth it all was.",
+    name: "Kaitlyn & James",
+    detail: "Roswell, GA · Day-of Coordination",
+  },
+  {
+    quote:
+      "We were DIY-ing everything and totally overwhelmed. The partial planning package was exactly what we needed — vendor recommendations, mood boards, budget help. She got us across the finish line with our sanity intact.",
+    name: "Maya & Devon",
+    detail: "Decatur, GA · Partial Planning",
+  },
+];

--- a/src/lib/testimonials.ts
+++ b/src/lib/testimonials.ts
@@ -1,0 +1,27 @@
+import { sanityClient } from "./sanity";
+import { testimonials as fallbackTestimonials, type Testimonial } from "../data/testimonials";
+
+export type { Testimonial };
+
+// Sort: explicit `order` ascending first (with nulls last), then newest
+// _createdAt as a tiebreaker so items without an order still feel fresh.
+const TESTIMONIALS_QUERY = `*[_type == "testimonial"] | order(coalesce(order, 99999) asc, _createdAt desc){
+  "name": name,
+  "quote": quote,
+  "detail": detail
+}`;
+
+export function getInitialTestimonials(): Testimonial[] | null {
+  return sanityClient ? null : fallbackTestimonials;
+}
+
+export async function getTestimonials(): Promise<Testimonial[]> {
+  if (!sanityClient) return fallbackTestimonials;
+  try {
+    const result = await sanityClient.fetch<Testimonial[]>(TESTIMONIALS_QUERY);
+    // Empty CMS = use fallback so the section never renders blank.
+    return result.length > 0 ? result : fallbackTestimonials;
+  } catch {
+    return fallbackTestimonials;
+  }
+}

--- a/studio/schemas/index.ts
+++ b/studio/schemas/index.ts
@@ -1,3 +1,4 @@
 import { post } from "./post";
+import { testimonial } from "./testimonial";
 
-export const schemaTypes = [post];
+export const schemaTypes = [post, testimonial];

--- a/studio/schemas/testimonial.ts
+++ b/studio/schemas/testimonial.ts
@@ -1,0 +1,52 @@
+import { defineField, defineType } from "sanity";
+
+export const testimonial = defineType({
+  name: "testimonial",
+  title: "Testimonial",
+  type: "document",
+  fields: [
+    defineField({
+      name: "name",
+      title: "Couple / Client Name",
+      type: "string",
+      description: 'e.g. "Priscila & Tri" — the ampersand renders in the system font.',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "quote",
+      title: "Quote",
+      type: "text",
+      rows: 5,
+      validation: (Rule) => Rule.required().max(600),
+    }),
+    defineField({
+      name: "detail",
+      title: "Detail Line",
+      type: "string",
+      description: 'Location + service, e.g. "Atlanta, GA · Full Coordination + Design".',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "eventDate",
+      title: "Event Date",
+      type: "date",
+      description: "Optional — date of the wedding/event.",
+    }),
+    defineField({
+      name: "order",
+      title: "Display Order",
+      type: "number",
+      description: "Lower numbers appear first. Leave blank to sort newest first.",
+    }),
+    defineField({
+      name: "image",
+      title: "Photo",
+      type: "image",
+      options: { hotspot: true },
+      description: "Optional — not yet rendered on the site, reserved for a future design pass.",
+    }),
+  ],
+  preview: {
+    select: { title: "name", subtitle: "detail", media: "image" },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds a `testimonial` schema to Sanity Studio (name, quote, detail, optional eventDate, optional order, optional image) and registers it in the studio schema index.
- Adds a fetch layer at [src/lib/testimonials.ts](src/lib/testimonials.ts) mirroring the journal/posts pattern: Sanity primary, static fallback for resilience and zero-flash initial render.
- Moves the previously-hardcoded testimonials into [src/data/testimonials.ts](src/data/testimonials.ts) as the fallback (same shape as `src/data/posts.ts`).
- Refactors [src/components/Testimonials.tsx](src/components/Testimonials.tsx) to fetch from Sanity on mount with a sync initial render. Empty Sanity result also falls back so Kind Words never goes blank.

## Design notes

- **Image field is in the schema but not rendered** — the existing card layout doesn't include photos, and adding a photo treatment is a design decision, not a CMS one. Schema field is optional so Amanda can attach photos in the studio now and we wire rendering in a later PR. Flagged in the schema description.
- **Sort order**: `coalesce(order, 99999) asc, _createdAt desc` — Amanda can pin specific items with the `order` number; everything else falls through to newest-first.
- **Hardcoded testimonials kept** as fallback per agreement — same pattern as posts. If Sanity is misconfigured or returns empty, the section still renders.

## Follow-up (not in this PR)

- Studio needs to be redeployed (`cd studio && npx sanity deploy`) for the new \"Testimonial\" content type to appear in [femmeevents.sanity.studio](https://femmeevents.sanity.studio). Hermes owns studio deploys.
- Once the studio is redeployed and Amanda has added at least 3 testimonials in Sanity, we can consider deleting the static fallback in a future cleanup PR.

Closes #32

## Test plan

- [ ] `npm run lint` (tsc --noEmit) — passes
- [ ] `npm run build` — passes
- [ ] Studio `tsc --noEmit` — passes
- [ ] Verified empty-Sanity path via live API (`*[_type==\"testimonial\"]` returns `[]`) — fallback renders the 3 original testimonials
- [ ] After studio redeploy: Amanda adds a test testimonial → appears on homepage Kind Words section
- [ ] Amanda edits / deletes a testimonial → updates reflect on next page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)