### PR TITLE
Vendor network backed by Sanity CMS (#39)

### DIFF
--- a/src/components/Vendors.tsx
+++ b/src/components/Vendors.tsx
@@ -1,62 +1,19 @@
+import { useEffect, useState } from "react";
 import { motion } from "motion/react";
-import { ExternalLink } from "lucide-react";
-
-interface Vendor {
-  name: string;
-  specialty: string;
-  url?: string;
-}
-
-interface VendorCategory {
-  label: string;
-  vendors: Vendor[];
-}
-
-const vendorCategories: VendorCategory[] = [
-  {
-    label: "Venues",
-    vendors: [
-      { name: "The Estate", specialty: "Historic mansion & gardens", url: "#" },
-      { name: "Barnsley Resort", specialty: "Rustic-luxury destination", url: "#" },
-      { name: "The Carlyle", specialty: "Elegant ballroom", url: "#" },
-    ],
-  },
-  {
-    label: "Florists",
-    vendors: [
-      { name: "Twisted Willow", specialty: "Organic garden-style arrangements", url: "#" },
-      { name: "Flora Fauna", specialty: "Modern sculptural designs", url: "#" },
-    ],
-  },
-  {
-    label: "Photographers",
-    vendors: [
-      { name: "Elyssa Beach", specialty: "Film & fine art wedding photography", url: "#" },
-      { name: "Fern & Frond", specialty: "Documentary-style storytelling", url: "#" },
-    ],
-  },
-  {
-    label: "Catering & Bar",
-    vendors: [
-      { name: "Elegant Events", specialty: "Southern-inspired catering", url: "#" },
-      { name: "The Pour Company", specialty: "Craft cocktail bar service", url: "#" },
-    ],
-  },
-  {
-    label: "Hair & Makeup",
-    vendors: [
-      { name: "Glamour ATA", specialty: "On-site bridal beauty team", url: "#" },
-    ],
-  },
-  {
-    label: "Music & DJ",
-    vendors: [
-      { name: "Atlanta Music Exchange", specialty: "Live bands & DJ packages", url: "#" },
-    ],
-  },
-];
+import { ExternalLink, Instagram } from "lucide-react";
+import {
+  getInitialVendorCategories,
+  getVendorCategories,
+  instagramUrl,
+  type Vendor,
+  type VendorCategory,
+} from "../lib/vendors";
+import { vendorCategories as fallbackCategories } from "../data/vendors";
 
 function VendorCard({ vendor, index }: { vendor: Vendor; index: number }) {
+  const igLink = instagramUrl(vendor.instagram);
+  const websiteLink = vendor.url && vendor.url !== "#" ? vendor.url : null;
+
   return (
     <motion.li
       initial={{ opacity: 0, y: 12 }}
@@ -73,23 +30,60 @@ function VendorCard({ vendor, index }: { vendor: Vendor; index: number }) {
           {vendor.specialty}
         </span>
       </div>
-      {vendor.url && (
-        <a
-          href={vendor.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="shrink-0 w-7 h-7 rounded-full border border-femme-plum/40 text-femme-plum flex items-center justify-center
-            opacity-0 group-hover:opacity-100 focus:opacity-100 hover:bg-femme-plum hover:text-white transition-all duration-200"
-          aria-label={`Visit ${vendor.name}`}
-        >
-          <ExternalLink size={13} strokeWidth={2} />
-        </a>
+      {(websiteLink || igLink) && (
+        <div className="shrink-0 flex items-center gap-2">
+          {websiteLink && (
+            <a
+              href={websiteLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-7 h-7 rounded-full border border-femme-plum/40 text-femme-plum flex items-center justify-center
+                opacity-0 group-hover:opacity-100 focus:opacity-100 hover:bg-femme-plum hover:text-white transition-all duration-200"
+              aria-label={`Visit ${vendor.name} website`}
+            >
+              <ExternalLink size={13} strokeWidth={2} />
+            </a>
+          )}
+          {igLink && (
+            <a
+              href={igLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-7 h-7 rounded-full border border-femme-plum/40 text-femme-plum flex items-center justify-center
+                opacity-0 group-hover:opacity-100 focus:opacity-100 hover:bg-femme-plum hover:text-white transition-all duration-200"
+              aria-label={`${vendor.name} on Instagram`}
+            >
+              <Instagram size={13} strokeWidth={2} />
+            </a>
+          )}
+        </div>
       )}
     </motion.li>
   );
 }
 
 export default function Vendors() {
+  const [categories, setCategories] = useState<VendorCategory[]>(
+    () => getInitialVendorCategories() ?? fallbackCategories,
+  );
+  const [errored, setErrored] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getVendorCategories()
+      .then((data) => {
+        if (cancelled) return;
+        if (data.length === 0) setErrored(true);
+        else setCategories(data);
+      })
+      .catch(() => {
+        if (!cancelled) setErrored(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <section className="py-16 md:py-24 px-6 md:px-24 bg-femme-cream">
       {/* Header */}
@@ -111,27 +105,35 @@ export default function Vendors() {
       </motion.div>
 
       {/* Category Grid */}
-      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-10">
-        {vendorCategories.map((cat, catIndex) => (
-          <motion.div
-            key={cat.label}
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ delay: catIndex * 0.1, duration: 0.5, ease: "easeOut" }}
-          >
-            <h3 className="text-2xl text-femme-plum font-balgin mb-4 flex items-center gap-3">
-              <span className="w-2 h-2 rounded-full bg-femme-orange shrink-0" />
-              {cat.label}
-            </h3>
-            <ul className="flex flex-col gap-3">
-              {cat.vendors.map((vendor, i) => (
-                <VendorCard key={vendor.name} vendor={vendor} index={i} />
-              ))}
-            </ul>
-          </motion.div>
-        ))}
-      </div>
+      {categories.length > 0 ? (
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-10">
+          {categories.map((cat, catIndex) => (
+            <motion.div
+              key={cat.label}
+              initial={{ opacity: 0, y: 24 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: catIndex * 0.1, duration: 0.5, ease: "easeOut" }}
+            >
+              <h3 className="text-2xl text-femme-plum font-balgin mb-4 flex items-center gap-3">
+                <span className="w-2 h-2 rounded-full bg-femme-orange shrink-0" />
+                {cat.label}
+              </h3>
+              <ul className="flex flex-col gap-3">
+                {cat.vendors.map((vendor, i) => (
+                  <VendorCard key={vendor.name} vendor={vendor} index={i} />
+                ))}
+              </ul>
+            </motion.div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-femme-dark/45 text-base font-system text-center py-16">
+          {errored
+            ? "Vendor list is taking a moment to load — check back shortly."
+            : "Vendor recommendations coming soon."}
+        </p>
+      )}
 
       {/* CTA */}
       <motion.div

--- a/src/data/vendors.ts
+++ b/src/data/vendors.ts
@@ -1,0 +1,55 @@
+export interface Vendor {
+  name: string;
+  specialty: string;
+  url?: string;
+  instagram?: string;
+}
+
+export interface VendorCategory {
+  label: string;
+  vendors: Vendor[];
+}
+
+export const vendorCategories: VendorCategory[] = [
+  {
+    label: "Venues",
+    vendors: [
+      { name: "The Estate", specialty: "Historic mansion & gardens", url: "#" },
+      { name: "Barnsley Resort", specialty: "Rustic-luxury destination", url: "#" },
+      { name: "The Carlyle", specialty: "Elegant ballroom", url: "#" },
+    ],
+  },
+  {
+    label: "Florists",
+    vendors: [
+      { name: "Twisted Willow", specialty: "Organic garden-style arrangements", url: "#" },
+      { name: "Flora Fauna", specialty: "Modern sculptural designs", url: "#" },
+    ],
+  },
+  {
+    label: "Photographers",
+    vendors: [
+      { name: "Elyssa Beach", specialty: "Film & fine art wedding photography", url: "#" },
+      { name: "Fern & Frond", specialty: "Documentary-style storytelling", url: "#" },
+    ],
+  },
+  {
+    label: "Catering & Bar",
+    vendors: [
+      { name: "Elegant Events", specialty: "Southern-inspired catering", url: "#" },
+      { name: "The Pour Company", specialty: "Craft cocktail bar service", url: "#" },
+    ],
+  },
+  {
+    label: "Hair & Makeup",
+    vendors: [
+      { name: "Glamour ATA", specialty: "On-site bridal beauty team", url: "#" },
+    ],
+  },
+  {
+    label: "Music & DJ",
+    vendors: [
+      { name: "Atlanta Music Exchange", specialty: "Live bands & DJ packages", url: "#" },
+    ],
+  },
+];

--- a/src/lib/vendors.ts
+++ b/src/lib/vendors.ts
@@ -1,0 +1,50 @@
+import { sanityClient } from "./sanity";
+import {
+  vendorCategories as fallbackCategories,
+  type Vendor,
+  type VendorCategory,
+} from "../data/vendors";
+
+export type { Vendor, VendorCategory };
+
+// Fetch each category and inline only its published vendors. Categories
+// with zero published vendors are filtered out client-side so the grid
+// doesn't render empty headings.
+const VENDORS_QUERY = `*[_type == "vendorCategory"] | order(coalesce(order, 99999) asc, label asc){
+  "label": label,
+  "vendors": *[_type == "vendor" && references(^._id) && published != false] | order(coalesce(order, 99999) asc, name asc){
+    "name": name,
+    "specialty": specialty,
+    "url": websiteUrl,
+    "instagram": instagramHandle
+  }
+}`;
+
+export function getInitialVendorCategories(): VendorCategory[] | null {
+  return sanityClient ? null : fallbackCategories;
+}
+
+export async function getVendorCategories(): Promise<VendorCategory[]> {
+  if (!sanityClient) return fallbackCategories;
+  try {
+    const result = await sanityClient.fetch<VendorCategory[]>(VENDORS_QUERY);
+    const populated = result.filter((c) => c.vendors.length > 0);
+    return populated.length > 0 ? populated : fallbackCategories;
+  } catch {
+    return fallbackCategories;
+  }
+}
+
+// Strips a leading "@" and any trailing slashes; returns null if the
+// handle is empty after normalization. Defensive against Amanda pasting
+// a full Instagram URL.
+export function instagramUrl(handle: string | undefined): string | null {
+  if (!handle) return null;
+  const trimmed = handle.trim();
+  if (!trimmed) return null;
+  const username = trimmed
+    .replace(/^https?:\/\/(www\.)?instagram\.com\//i, "")
+    .replace(/^@/, "")
+    .replace(/\/+$/, "");
+  return username ? `https://instagram.com/${username}` : null;
+}

--- a/studio/schemas/index.ts
+++ b/studio/schemas/index.ts
@@ -1,4 +1,6 @@
 import { post } from "./post";
 import { testimonial } from "./testimonial";
+import { vendorCategory } from "./vendorCategory";
+import { vendor } from "./vendor";
 
-export const schemaTypes = [post, testimonial];
+export const schemaTypes = [post, testimonial, vendorCategory, vendor];

--- a/studio/schemas/vendor.ts
+++ b/studio/schemas/vendor.ts
@@ -1,0 +1,69 @@
+import { defineField, defineType } from "sanity";
+
+export const vendor = defineType({
+  name: "vendor",
+  title: "Vendor",
+  type: "document",
+  fields: [
+    defineField({
+      name: "name",
+      title: "Vendor Name",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "specialty",
+      title: "Specialty",
+      type: "string",
+      description: 'Short tagline, e.g. "Organic garden-style arrangements".',
+      validation: (Rule) => Rule.required().max(120),
+    }),
+    defineField({
+      name: "category",
+      title: "Category",
+      type: "reference",
+      to: [{ type: "vendorCategory" }],
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "websiteUrl",
+      title: "Website URL",
+      type: "url",
+      description: "Optional — full URL including https://.",
+    }),
+    defineField({
+      name: "instagramHandle",
+      title: "Instagram Handle",
+      type: "string",
+      description: 'Optional — username only, with or without the leading "@".',
+    }),
+    defineField({
+      name: "published",
+      title: "Visible on Site",
+      type: "boolean",
+      description: "Uncheck to hide from the website without deleting.",
+      initialValue: true,
+    }),
+    defineField({
+      name: "order",
+      title: "Display Order",
+      type: "number",
+      description:
+        "Order within the category. Lower numbers appear first; leave blank to sort alphabetically.",
+    }),
+  ],
+  preview: {
+    select: {
+      title: "name",
+      subtitle: "category.label",
+      published: "published",
+    },
+    prepare({ title, subtitle, published }) {
+      const visibility = published === false ? " (hidden)" : "";
+      return {
+        title: `${title}${visibility}`,
+        subtitle: subtitle ?? "Uncategorized",
+      };
+    },
+  },
+});

--- a/studio/schemas/vendorCategory.ts
+++ b/studio/schemas/vendorCategory.ts
@@ -1,0 +1,31 @@
+import { defineField, defineType } from "sanity";
+
+export const vendorCategory = defineType({
+  name: "vendorCategory",
+  title: "Vendor Category",
+  type: "document",
+  fields: [
+    defineField({
+      name: "label",
+      title: "Label",
+      type: "string",
+      description: 'e.g. "Venues", "Florists", "Photographers".',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "order",
+      title: "Display Order",
+      type: "number",
+      description: "Lower numbers appear first. Leave blank to sort alphabetically.",
+    }),
+  ],
+  preview: {
+    select: { title: "label", subtitle: "order" },
+    prepare({ title, subtitle }) {
+      return {
+        title,
+        subtitle: subtitle != null ? `Order: ${subtitle}` : "No order set",
+      };
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Two new Sanity schemas — `vendorCategory` (label, order) and `vendor` (name, specialty, category reference, websiteUrl, instagramHandle, published, order). Categories are a separate document type so Amanda can add, remove, and reorder them without code changes.
- Fetch layer in [src/lib/vendors.ts](src/lib/vendors.ts) follows the established Sanity-or-fallback pattern (matches [src/lib/posts.ts](src/lib/posts.ts) and [src/lib/testimonials.ts](src/lib/testimonials.ts)).
- Static fallback in [src/data/vendors.ts](src/data/vendors.ts) — the existing hardcoded list lifted out of the component.
- [Vendors.tsx](src/components/Vendors.tsx) now fetches from Sanity, renders an Instagram icon (`lucide Instagram`) alongside the existing `ExternalLink` when a handle is present, and shows a defensive empty-state message only if both Sanity and the fallback resolve to zero categories.

## Design notes

- **Visibility toggle** — `published` boolean (default `true`) on the vendor schema. Hides on the site without deleting; the GROQ query filters with `published != false`. Hard delete still happens via the Sanity studio when desired.
- **Instagram URL handling** — `instagramUrl()` in [src/lib/vendors.ts](src/lib/vendors.ts) accepts `kayla`, `@kayla`, or a full `https://instagram.com/kayla/` URL and normalizes them all. Defensive in case Amanda pastes a full URL into the handle field.
- **Sort order** — categories sort by `coalesce(order, 99999) asc, label asc`; vendors within a category sort by `coalesce(order, 99999) asc, name asc`. Manual `order` wins; alphabetical fallback for items without one.
- **Categories with zero published vendors** are filtered out client-side so the grid never shows an empty heading.
- **Fallback pattern kept** per agreement (consistent with #21 and #32). If both Sanity and the fallback are empty, the section shows a polite \"coming soon\" / error message instead of breaking the page.

## Follow-up (not in this PR)

- Studio needs a redeploy (`cd studio && npx sanity deploy`) for the new \"Vendor\" and \"Vendor Category\" types to appear in [femmeevents.sanity.studio](https://femmeevents.sanity.studio). Hermes owns studio deploys.
- After Amanda seeds the CMS with the current vendor list and confirms the site reads from Sanity, we can drop the static fallback in a future cleanup PR.

Closes #39

## Test plan

- [x] `npm run lint` (tsc --noEmit) — passes
- [x] `npm run build` — passes
- [x] Studio `tsc --noEmit` — passes
- [x] Verified empty-Sanity path via live API (`*[_type==\"vendorCategory\"]` returns `[]`) — fallback renders the original 6 categories unchanged
- [ ] After studio redeploy: Amanda adds a category + vendor → appears on homepage Our People section
- [ ] Vendor with website + Instagram → both icons render on hover
- [ ] Vendor with `published = false` → not rendered on site
- [ ] Category with zero published vendors → header not rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)