### PR TITLE
Mobile carousels for Services + Testimonials (#50, #54)

### DIFF
--- a/src/components/CarouselDots.tsx
+++ b/src/components/CarouselDots.tsx
@@ -1,0 +1,43 @@
+interface CarouselDotsProps {
+  count: number;
+  activeIndex: number;
+  onSelect: (index: number) => void;
+  label: string;
+  className?: string;
+}
+
+export default function CarouselDots({
+  count,
+  activeIndex,
+  onSelect,
+  label,
+  className = "",
+}: CarouselDotsProps) {
+  if (count <= 1) return null;
+  return (
+    <div
+      role="tablist"
+      aria-label={label}
+      className={`flex items-center justify-center gap-2.5 ${className}`}
+    >
+      {Array.from({ length: count }).map((_, i) => {
+        const active = i === activeIndex;
+        return (
+          <button
+            key={i}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-label={`Go to slide ${i + 1}`}
+            onClick={() => onSelect(i)}
+            className={`h-2 rounded-full transition-all duration-200 ${
+              active
+                ? "w-6 bg-femme-orange"
+                : "w-2 bg-femme-plum/30 hover:bg-femme-plum/60"
+            }`}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
+import CarouselDots from "./CarouselDots";
+import { useCarouselIndex } from "../lib/useCarouselIndex";
 
 const services = [
   {
@@ -59,7 +61,37 @@ const addons = [
   "Second coordinator",
 ];
 
-function ServiceCard({ service, index }: { service: typeof services[0]; index: number }) {
+function IncludesList({
+  service,
+}: {
+  service: (typeof services)[0];
+}) {
+  return (
+    <ul className="flex flex-col gap-2 mb-6">
+      {service.includes.map((item, i) => (
+        <li key={i} className="flex gap-2.5 items-start">
+          <span className="w-1.5 h-1.5 rounded-full bg-femme-pink shrink-0 mt-[6px]" />
+          <span className="text-white/90 text-sm leading-snug font-system">
+            {item}
+          </span>
+        </li>
+      ))}
+      {service.note && (
+        <li className="text-white/50 text-xs italic pl-4 font-system mt-1">
+          {service.note}
+        </li>
+      )}
+    </ul>
+  );
+}
+
+function ServiceCard({
+  service,
+  index,
+}: {
+  service: (typeof services)[0];
+  index: number;
+}) {
   const [hovered, setHovered] = useState(false);
 
   return (
@@ -68,7 +100,7 @@ function ServiceCard({ service, index }: { service: typeof services[0]; index: n
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ delay: index * 0.15, duration: 0.6, ease: "easeOut" }}
-      className="relative h-[700px] rounded-2xl overflow-hidden cursor-pointer shadow-xl"
+      className="relative shrink-0 w-[85vw] md:w-auto h-[640px] md:h-[700px] snap-start md:snap-align-none rounded-2xl overflow-hidden cursor-pointer shadow-xl"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
@@ -86,56 +118,48 @@ function ServiceCard({ service, index }: { service: typeof services[0]; index: n
       {/* Base gradient — always visible at bottom */}
       <div className="absolute inset-0 bg-gradient-to-t from-femme-dark/90 via-femme-dark/30 to-transparent" />
 
-      {/* Hover overlay — deepens the gradient */}
+      {/* Hover overlay — desktop only, deepens the gradient */}
       <motion.div
-        className="absolute inset-0 bg-femme-dark/40"
+        className="absolute inset-0 bg-femme-dark/40 hidden md:block"
         animate={{ opacity: hovered ? 1 : 0 }}
         transition={{ duration: 0.4 }}
       />
 
+      {/* Mobile static overlay so the always-visible includes stay legible */}
+      <div className="absolute inset-0 bg-femme-dark/30 md:hidden" />
+
       {/* Card content */}
       <div className="absolute inset-0 flex flex-col justify-end p-8">
+        {/* Mobile: includes always visible — no hover state on touch */}
+        <div className="md:hidden">
+          <IncludesList service={service} />
+        </div>
 
-        {/* Bullet list — slides up on hover */}
+        {/* Desktop: includes slide up on hover */}
         <AnimatePresence>
           {hovered && (
-            <motion.ul
+            <motion.div
+              key="includes"
               initial={{ opacity: 0, y: 16 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: 16 }}
               transition={{ duration: 0.35, ease: "easeOut" }}
-              className="flex flex-col gap-2 mb-6"
+              className="hidden md:block"
             >
-              {service.includes.map((item, i) => (
-                <motion.li
-                  key={i}
-                  initial={{ opacity: 0, x: -8 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ delay: i * 0.04, duration: 0.3 }}
-                  className="flex gap-2.5 items-start"
-                >
-                  <span className="w-1.5 h-1.5 rounded-full bg-femme-pink shrink-0 mt-[6px]" />
-                  <span className="text-white/90 text-sm leading-snug font-system">{item}</span>
-                </motion.li>
-              ))}
-              {service.note && (
-                <li className="text-white/50 text-xs italic pl-4 font-system mt-1">{service.note}</li>
-              )}
-            </motion.ul>
+              <IncludesList service={service} />
+            </motion.div>
           )}
         </AnimatePresence>
 
         {/* Title block — always visible */}
         <div className="mb-5">
           <h3
-            className="text-white text-6xl leading-tight mb-2"
+            className="text-white text-5xl md:text-6xl leading-tight mb-2"
             style={{ fontFamily: "Frunchy Sage, serif", fontWeight: "bold" }}
           >
             {service.title}
           </h3>
-          <p
-            className="text-femme-pink text-sm uppercase tracking-[0.25em] font-bold font-system"
-          >
+          <p className="text-femme-pink text-sm uppercase tracking-[0.25em] font-bold font-system">
             {service.subtitle}
           </p>
         </div>
@@ -159,6 +183,10 @@ function ServiceCard({ service, index }: { service: typeof services[0]; index: n
 }
 
 export default function Services() {
+  const { ref, index, scrollToIndex } = useCarouselIndex<HTMLDivElement>(
+    services.length,
+  );
+
   return (
     <section id="services" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender">
       {/* Header */}
@@ -169,12 +197,31 @@ export default function Services() {
         <div className="h-1 w-32 bg-femme-orange" />
       </div>
 
-      {/* Service Cards */}
-      <div className="grid md:grid-cols-3 gap-6">
-        {services.map((service, index) => (
-          <ServiceCard key={index} service={service} index={index} />
+      {/* Service Cards: horizontal scroll on mobile, grid on desktop.
+          The negative margin lets cards flow to the screen edge while
+          the section keeps its px-6 padding for everything else. */}
+      <div
+        ref={ref}
+        className="flex md:grid md:grid-cols-3 gap-6
+          overflow-x-auto md:overflow-visible
+          snap-x snap-mandatory md:snap-none
+          scrollbar-hide
+          -mx-6 md:mx-0 px-6 md:px-0
+          pb-2 md:pb-0"
+      >
+        {services.map((service, i) => (
+          <ServiceCard key={i} service={service} index={i} />
         ))}
       </div>
+
+      {/* Mobile-only dot indicators */}
+      <CarouselDots
+        count={services.length}
+        activeIndex={index}
+        onSelect={scrollToIndex}
+        label="Service packages"
+        className="mt-6 md:hidden"
+      />
 
       {/* À La Carte Add-ons */}
       <motion.div

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -7,6 +7,8 @@ import {
   type Testimonial,
 } from "../lib/testimonials";
 import { testimonials as fallbackTestimonials } from "../data/testimonials";
+import { useCarouselIndex } from "../lib/useCarouselIndex";
+import CarouselDots from "./CarouselDots";
 
 function Name({ children }: { children: string }) {
   const parts = children.split("&");
@@ -39,6 +41,10 @@ export default function Testimonials() {
     };
   }, []);
 
+  const { ref, index, scrollToIndex } = useCarouselIndex<HTMLDivElement>(
+    testimonials.length,
+  );
+
   return (
     <section className="py-16 md:py-24 px-6 md:px-24 bg-femme-pale">
       {/* Header row with arrow */}
@@ -59,60 +65,85 @@ export default function Testimonials() {
 
       {/* Cards + arrow */}
       <div className="flex flex-col md:flex-row md:items-center gap-6">
-        <div className="grid md:grid-cols-3 gap-8 flex-1">
-        {testimonials.map((t, index) => (
-          <motion.div
-            key={index}
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            whileHover={{ y: -8 }}
-            transition={{ delay: index * 0.15, duration: 0.5, type: "spring", stiffness: 280, damping: 20 }}
-            className="bg-femme-cream border border-femme-pink/40 p-8 flex flex-col gap-6 rounded-2xl shadow-sm cursor-default"
-          >
-            {/* Decorative quote mark */}
-            <span
-              className="text-8xl leading-none text-femme-plum/20 select-none"
-              style={{ fontFamily: "Frunchy Sage, serif", fontWeight: "bold" }}
-              aria-hidden="true"
+        {/* Mobile: horizontal scroll. Desktop: 3-col grid. */}
+        <div
+          ref={ref}
+          className="flex md:grid md:grid-cols-3 gap-8 flex-1
+            overflow-x-auto md:overflow-visible
+            snap-x snap-mandatory md:snap-none
+            scrollbar-hide
+            -mx-6 md:mx-0 px-6 md:px-0
+            pb-2 md:pb-0"
+        >
+          {testimonials.map((t, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              whileHover={{ y: -8 }}
+              transition={{
+                delay: i * 0.15,
+                duration: 0.5,
+                type: "spring",
+                stiffness: 280,
+                damping: 20,
+              }}
+              className="shrink-0 w-[85vw] md:w-auto snap-start md:snap-align-none
+                bg-femme-cream border border-femme-pink/40 p-8 flex flex-col gap-6 rounded-2xl shadow-sm cursor-default"
             >
-              "
-            </span>
-
-            {/* Quote */}
-            <p className="text-femme-dark/85 text-lg leading-relaxed flex-grow -mt-6">
-              {t.quote}
-            </p>
-
-            {/* Divider */}
-            <div className="h-px bg-femme-pink/40" />
-
-            {/* Attribution */}
-            <div className="flex flex-col gap-2 items-center text-center">
-              <span className="text-femme-plum text-3xl font-bold font-balgin">
-                <Name>{t.name}</Name>
+              {/* Decorative quote mark */}
+              <span
+                className="text-8xl leading-none text-femme-plum/20 select-none"
+                style={{ fontFamily: "Frunchy Sage, serif", fontWeight: "bold" }}
+                aria-hidden="true"
+              >
+                "
               </span>
-              <span className="text-femme-dark/50 text-sm font-system">
-                {t.detail}
-              </span>
-            </div>
-          </motion.div>
-        ))}
+
+              {/* Quote */}
+              <p className="text-femme-dark/85 text-lg leading-relaxed flex-grow -mt-6">
+                {t.quote}
+              </p>
+
+              {/* Divider */}
+              <div className="h-px bg-femme-pink/40" />
+
+              {/* Attribution */}
+              <div className="flex flex-col gap-2 items-center text-center">
+                <span className="text-femme-plum text-3xl font-bold font-balgin">
+                  <Name>{t.name}</Name>
+                </span>
+                <span className="text-femme-dark/50 text-sm font-system">
+                  {t.detail}
+                </span>
+              </div>
+            </motion.div>
+          ))}
         </div>
 
-        {/* Next arrow — centered with cards, after the last one */}
+        {/* Next arrow — desktop only (mobile uses swipe + dots) */}
         <motion.button
           whileHover={{ x: 4 }}
           whileTap={{ scale: 0.93 }}
           transition={{ type: "spring", stiffness: 300, damping: 18 }}
-          className="shrink-0 w-14 h-14 rounded-full border-2 border-femme-plum text-femme-plum
-            flex items-center justify-center hover:bg-femme-plum hover:text-white
-            transition-colors duration-200 cursor-pointer self-end md:self-auto"
+          className="hidden md:flex shrink-0 w-14 h-14 rounded-full border-2 border-femme-plum text-femme-plum
+            items-center justify-center hover:bg-femme-plum hover:text-white
+            transition-colors duration-200 cursor-pointer self-auto"
           aria-label="Next testimonials"
         >
           <ArrowRight size={22} strokeWidth={2} />
         </motion.button>
       </div>
+
+      {/* Mobile-only dot indicators */}
+      <CarouselDots
+        count={testimonials.length}
+        activeIndex={index}
+        onSelect={scrollToIndex}
+        label="Testimonials"
+        className="mt-6 md:hidden"
+      />
     </section>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -108,6 +108,17 @@
   z-index: 1;
 }
 
+/* ─── Scrollbar Hide ───────────────────────────── */
+/* For horizontal mobile carousels — keeps the swipe gesture
+   without showing a scrollbar that breaks the visual rhythm. */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 /* ─── Reduced Motion ───────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/src/lib/useCarouselIndex.ts
+++ b/src/lib/useCarouselIndex.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from "react";
+
+// Tracks which child of a horizontally-scrolling container is currently
+// the "active" card by intersection ratio. Returns a ref to attach to
+// the scroll container, the active index, and a programmatic scroller
+// for click-to-navigate dots.
+//
+// Built for mobile-only carousels: on desktop the same children render
+// in a grid (no horizontal scroll) and the hook stays harmlessly idle
+// because IntersectionObserver fires once per child and `setIndex` ends
+// up at 0 — the dot indicator is hidden in that layout anyway.
+export function useCarouselIndex<T extends HTMLElement = HTMLDivElement>(
+  itemCount: number,
+) {
+  const ref = useRef<T | null>(null);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || itemCount === 0) return;
+    const cards = Array.from(el.children) as HTMLElement[];
+    if (cards.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (!visible) return;
+        const i = cards.indexOf(visible.target as HTMLElement);
+        if (i >= 0) setIndex(i);
+      },
+      { root: el, threshold: [0.5, 0.75, 1] },
+    );
+    cards.forEach((c) => observer.observe(c));
+    return () => observer.disconnect();
+  }, [itemCount]);
+
+  const scrollToIndex = (i: number) => {
+    const el = ref.current;
+    if (!el) return;
+    const card = el.children[i] as HTMLElement | undefined;
+    if (!card) return;
+    el.scrollTo({ left: card.offsetLeft - el.offsetLeft, behavior: "smooth" });
+  };
+
+  return { ref, index, scrollToIndex };
+}


### PR DESCRIPTION
## Summary

Converts both **Services** and **Testimonials** sections from vertical-stack-on-mobile to horizontal swipeable carousels using CSS scroll-snap. Desktop grid layouts are untouched.

Bundling both issues per the user's explicit request — they share a hook and dot-indicator component, and shipping them together avoids two near-identical PRs.

## Shared building blocks

- [src/lib/useCarouselIndex.ts](src/lib/useCarouselIndex.ts) — small hook that tracks the active card via `IntersectionObserver` and exposes a `scrollToIndex()` for click-to-navigate dots. Idle on desktop where children render in a grid.
- [src/components/CarouselDots.tsx](src/components/CarouselDots.tsx) — pill-shaped dot indicator. Active dot is `femme-orange` (10% accent per [#41](https://github.com/sabnanikl-dev/Femme-Events-Website/issues/41)), inactive is `femme-plum/30`. Hidden on desktop via `md:hidden` from each consumer.
- `.scrollbar-hide` utility in [src/index.css](src/index.css) — hides the native scrollbar on the carousel container without affecting touch scroll.

## Services (#50)

- **Mobile**: cards are `min-w-[85vw]` with `snap-start` so the next card peeks. Card height drops slightly to `h-[640px]` so includes fit comfortably. Includes list is **always visible** (no hover state on touch — went with the always-visible option from the issue rather than tap-to-expand for simplicity). A static `bg-femme-dark/30` overlay keeps text legible over the photo.
- **Desktop**: 3-col grid + hover-to-reveal includes are preserved exactly as before.
- Extracted `IncludesList` to avoid duplicating the bullet markup between the mobile-static and desktop-animated branches.

## Testimonials (#54)

- **Mobile**: cards are `min-w-[85vw]` with `snap-start`. The `whileHover` lift is harmless on mobile (no hover state) and stays for desktop.
- **Desktop**: 3-col grid preserved; the \"Next\" arrow is now `hidden md:flex` so it only renders where it's relevant.

## Test plan

- [x] `npm run lint` (tsc --noEmit) — passes
- [x] `npm run build` — passes
- [x] Dev server boots and serves homepage
- [ ] **Manual on-device testing needed** — I haven't been able to touch-test on a real phone. Verify:
  - [ ] Swiping a card snaps cleanly to the next one
  - [ ] Dot indicator follows the active card during swipe
  - [ ] Tapping a dot scrolls smoothly to that card
  - [ ] No horizontal page-level scroll leaks (carousel uses `-mx-6 px-6` to bleed to the screen edge while keeping the section's outer padding)
- [ ] Resize from mobile to desktop and back — layout switches cleanly with no orphaned scroll state
- [ ] Reduced-motion preference respected (the global `prefers-reduced-motion` rule in `index.css` already disables transitions)

## Design notes

- **Always-visible includes on mobile** chosen over tap-to-expand. The issue listed both as acceptable. Tap-to-expand would require persistent expanded state and an additional tap target inside an already-tappable card — felt like more UX risk than reward for the same content.
- **No new library**. Pure CSS snap + a 30-line hook. Sticking with the issue's \"no heavy carousel library needed\" guidance.
- **The arrow button on desktop Testimonials still has no onClick** — it didn't before either. That's its own separate issue and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)