### PR TITLE
Polish carousel accessibility and local Sanity setup

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,23 @@
+# Local Development Notes
+
+## Sanity CORS origins
+
+The Femme Events site fetches public content from Sanity in local development and local build previews. The Sanity project CORS allowlist should include the local origins used by Vite:
+
+- `http://localhost:3000`
+- `http://127.0.0.1:3000`
+- `http://localhost:5173`
+- `http://127.0.0.1:5173`
+- `http://localhost:4173`
+- `http://127.0.0.1:4173`
+
+These should be added without credentials unless a future authenticated Studio/API workflow requires otherwise.
+
+Useful commands from the `studio/` directory:
+
+```bash
+npx sanity cors list
+npx sanity cors add http://127.0.0.1:4173 --no-credentials
+```
+
+Avoid wildcard CORS origins for this project.

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { motion } from "motion/react";
-import { ArrowRight } from "lucide-react";
 import {
   getInitialTestimonials,
   getTestimonials,
@@ -63,78 +62,62 @@ export default function Testimonials() {
         </div>
       </motion.div>
 
-      {/* Cards + arrow */}
-      <div className="flex flex-col md:flex-row md:items-center gap-6">
-        {/* Mobile: horizontal scroll. Desktop: 3-col grid. */}
-        <div
-          ref={ref}
-          className="flex md:grid md:grid-cols-3 gap-8 flex-1
-            overflow-x-auto md:overflow-visible
-            snap-x snap-mandatory md:snap-none
-            scrollbar-hide
-            -mx-6 md:mx-0 px-6 md:px-0
-            pb-2 md:pb-0"
-        >
-          {testimonials.map((t, i) => (
-            <motion.div
-              key={i}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              whileHover={{ y: -8 }}
-              transition={{
-                delay: i * 0.15,
-                duration: 0.5,
-                type: "spring",
-                stiffness: 280,
-                damping: 20,
-              }}
-              className="shrink-0 w-[85vw] md:w-auto snap-start md:snap-align-none
-                bg-femme-cream border border-femme-pink/40 p-8 flex flex-col gap-6 rounded-2xl shadow-sm cursor-default"
+      {/* Mobile: horizontal scroll. Desktop: 3-col grid. */}
+      <div
+        ref={ref}
+        className="flex md:grid md:grid-cols-3 gap-8
+          overflow-x-auto md:overflow-visible
+          snap-x snap-mandatory md:snap-none
+          scrollbar-hide
+          -mx-6 md:mx-0 px-6 md:px-0
+          pb-2 md:pb-0"
+      >
+        {testimonials.map((t, i) => (
+          <motion.div
+            key={i}
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            whileHover={{ y: -8 }}
+            transition={{
+              delay: i * 0.15,
+              duration: 0.5,
+              type: "spring",
+              stiffness: 280,
+              damping: 20,
+            }}
+            className="shrink-0 w-[85vw] md:w-auto snap-start md:snap-align-none
+              bg-femme-cream border border-femme-pink/40 p-8 flex flex-col gap-6 rounded-2xl shadow-sm cursor-default"
+          >
+            {/* Decorative quote mark */}
+            <span
+              className="text-8xl leading-none text-femme-plum/20 select-none"
+              style={{ fontFamily: "Frunchy Sage, serif", fontWeight: "bold" }}
+              aria-hidden="true"
             >
-              {/* Decorative quote mark */}
-              <span
-                className="text-8xl leading-none text-femme-plum/20 select-none"
-                style={{ fontFamily: "Frunchy Sage, serif", fontWeight: "bold" }}
-                aria-hidden="true"
-              >
-                "
+              "
+            </span>
+
+            {/* Quote */}
+            <p className="text-femme-dark/85 text-lg leading-relaxed flex-grow -mt-6">
+              {t.quote}
+            </p>
+
+            {/* Divider */}
+            <div className="h-px bg-femme-pink/40" />
+
+            {/* Attribution */}
+            <div className="flex flex-col gap-2 items-center text-center">
+              <span className="text-femme-plum text-3xl font-bold font-balgin">
+                <Name>{t.name}</Name>
               </span>
-
-              {/* Quote */}
-              <p className="text-femme-dark/85 text-lg leading-relaxed flex-grow -mt-6">
-                {t.quote}
-              </p>
-
-              {/* Divider */}
-              <div className="h-px bg-femme-pink/40" />
-
-              {/* Attribution */}
-              <div className="flex flex-col gap-2 items-center text-center">
-                <span className="text-femme-plum text-3xl font-bold font-balgin">
-                  <Name>{t.name}</Name>
-                </span>
-                <span className="text-femme-dark/50 text-sm font-system">
-                  {t.detail}
-                </span>
-              </div>
-            </motion.div>
+              <span className="text-femme-dark/50 text-sm font-system">
+                {t.detail}
+              </span>
+            </div>
+          </motion.div>
           ))}
         </div>
-
-        {/* Next arrow — desktop only (mobile uses swipe + dots) */}
-        <motion.button
-          whileHover={{ x: 4 }}
-          whileTap={{ scale: 0.93 }}
-          transition={{ type: "spring", stiffness: 300, damping: 18 }}
-          className="hidden md:flex shrink-0 w-14 h-14 rounded-full border-2 border-femme-plum text-femme-plum
-            items-center justify-center hover:bg-femme-plum hover:text-white
-            transition-colors duration-200 cursor-pointer self-auto"
-          aria-label="Next testimonials"
-        >
-          <ArrowRight size={22} strokeWidth={2} />
-        </motion.button>
-      </div>
 
       {/* Mobile-only dot indicators */}
       <CarouselDots

--- a/src/lib/useCarouselIndex.ts
+++ b/src/lib/useCarouselIndex.ts
@@ -41,7 +41,13 @@ export function useCarouselIndex<T extends HTMLElement = HTMLDivElement>(
     if (!el) return;
     const card = el.children[i] as HTMLElement | undefined;
     if (!card) return;
-    el.scrollTo({ left: card.offsetLeft - el.offsetLeft, behavior: "smooth" });
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    el.scrollTo({
+      left: card.offsetLeft - el.offsetLeft,
+      behavior: prefersReducedMotion ? "auto" : "smooth",
+    });
   };
 
   return { ref, index, scrollToIndex };


### PR DESCRIPTION
## Summary

- Respect `prefers-reduced-motion` for carousel dot navigation by switching programmatic scroll from `smooth` to `auto` when reduced motion is enabled.
- Remove the desktop Testimonials arrow because the section is a static desktop grid and the arrow had no valid action.
- Document the Sanity local CORS origins used by Vite dev/build preview.

## Sanity CORS operations completed

I also updated the Sanity project allowlist outside the repo with these no-credentials local origins:

- `http://127.0.0.1:3000`
- `http://localhost:5173`
- `http://127.0.0.1:5173`
- `http://localhost:4173`
- `http://127.0.0.1:4173`

Existing origins like `http://localhost:3000`, production domains, and Studio remain unchanged.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] Local built preview at `http://127.0.0.1:4173` no longer shows Sanity CORS errors; only the pre-existing missing grain texture 404 remains.

Closes #67
Closes #68
Closes #69
