### PR TITLE
Optimize journal images for web + mobile (#55)

### DIFF
--- a/src/lib/imageUrl.ts
+++ b/src/lib/imageUrl.ts
@@ -1,0 +1,60 @@
+// Sanity image URL helpers. These only modify Sanity CDN URLs;
+// non-Sanity URLs (e.g. the `/photos/*.jpg` static fallbacks) are
+// passed through untouched so callers can safely use these helpers
+// against either source.
+
+const SANITY_HOST = "cdn.sanity.io";
+
+interface SanityImageOpts {
+  w?: number;
+  q?: number;
+  fit?: "max" | "crop";
+}
+
+export function isSanityUrl(url: string | undefined): url is string {
+  return typeof url === "string" && url.includes(SANITY_HOST);
+}
+
+// Returns a Sanity CDN URL with width / format / quality params applied.
+// Non-Sanity URLs are returned unchanged.
+export function sanityImageUrl(url: string, opts: SanityImageOpts = {}): string {
+  if (!isSanityUrl(url)) return url;
+  const params = new URLSearchParams();
+  if (opts.w) params.set("w", String(opts.w));
+  params.set("q", String(opts.q ?? 80));
+  params.set("fit", opts.fit ?? "max");
+  // auto=format lets Sanity negotiate WebP / AVIF based on the browser's
+  // Accept header — modern browsers get the modern format, older clients
+  // still get JPEG.
+  params.set("auto", "format");
+  return `${url}?${params.toString()}`;
+}
+
+// Builds a `srcSet` string covering the given widths. Returns undefined
+// for non-Sanity URLs so callers can omit the attribute entirely
+// (otherwise the browser would use a single static URL repeated at
+// every density, which serves no purpose).
+export function buildSrcSet(
+  url: string,
+  widths: number[],
+  opts: Omit<SanityImageOpts, "w"> = {},
+): string | undefined {
+  if (!isSanityUrl(url)) return undefined;
+  return widths
+    .map((w) => `${sanityImageUrl(url, { ...opts, w })} ${w}w`)
+    .join(", ");
+}
+
+// Sanity asset URLs encode original dimensions in the path:
+//   .../<projectId>/<dataset>/<assetId>-1600x1067.jpg
+// Parsing them lets us set explicit width / height attributes on the
+// img tag, which helps the browser reserve layout space before bytes
+// arrive (CLS defense).
+export function parseSanityDimensions(
+  url: string | undefined,
+): { width: number; height: number } | null {
+  if (!isSanityUrl(url)) return null;
+  const match = /-(\d+)x(\d+)\.[a-zA-Z0-9]+(?:\?|$)/.exec(url);
+  if (!match) return null;
+  return { width: Number(match[1]), height: Number(match[2]) };
+}

--- a/src/pages/BlogIndex.tsx
+++ b/src/pages/BlogIndex.tsx
@@ -3,8 +3,17 @@ import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "motion/react";
 import { ArrowRight } from "lucide-react";
 import { getInitialPosts, getPosts, formatPostDate, type Post } from "../lib/posts";
+import {
+  buildSrcSet,
+  parseSanityDimensions,
+  sanityImageUrl,
+} from "../lib/imageUrl";
+
+const FEATURED_WIDTHS = [400, 600, 800, 1200, 1600];
+const CARD_WIDTHS = [400, 600, 800, 1200];
 
 function FeaturedPost({ post }: { post: Post }) {
+  const dims = parseSanityDimensions(post.image);
   return (
     <motion.article
       initial={{ opacity: 0, y: 24 }}
@@ -15,7 +24,11 @@ function FeaturedPost({ post }: { post: Post }) {
       {/* Image */}
       <div className="overflow-hidden aspect-[4/3] md:aspect-auto">
         <img
-          src={post.image}
+          src={sanityImageUrl(post.image, { w: 1200 })}
+          srcSet={buildSrcSet(post.image, FEATURED_WIDTHS)}
+          sizes="(min-width: 768px) 30vw, 100vw"
+          width={dims?.width}
+          height={dims?.height}
           alt={post.title}
           fetchPriority="high"
           decoding="async"
@@ -52,6 +65,7 @@ function FeaturedPost({ post }: { post: Post }) {
 }
 
 function PostCard({ post, index }: { post: Post; index: number }) {
+  const dims = parseSanityDimensions(post.image);
   return (
     <motion.article
       layout
@@ -64,7 +78,11 @@ function PostCard({ post, index }: { post: Post; index: number }) {
       {/* Image */}
       <div className="overflow-hidden rounded-xl aspect-[16/5.04]">
         <img
-          src={post.image}
+          src={sanityImageUrl(post.image, { w: 800 })}
+          srcSet={buildSrcSet(post.image, CARD_WIDTHS)}
+          sizes="(min-width: 768px) 45vw, 100vw"
+          width={dims?.width}
+          height={dims?.height}
           alt={post.title}
           loading="lazy"
           decoding="async"

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -4,6 +4,13 @@ import { motion } from "motion/react";
 import { ArrowLeft } from "lucide-react";
 import { PortableText, type PortableTextComponents } from "@portabletext/react";
 import { getInitialPost, getPost, formatPostDate, type Post } from "../lib/posts";
+import {
+  buildSrcSet,
+  parseSanityDimensions,
+  sanityImageUrl,
+} from "../lib/imageUrl";
+
+const HERO_WIDTHS = [600, 900, 1200, 1600, 2000];
 
 // Custom serializers so Portable Text output matches the visual style of
 // the existing markdown-ish renderer (italic h2, plum-dot bullets, etc.).
@@ -104,12 +111,18 @@ export default function BlogPost() {
   if (post === undefined) return null;
   if (post === null) return <Navigate to="/journal" replace />;
 
+  const heroDims = parseSanityDimensions(post.image);
+
   return (
     <div className="min-h-screen bg-femme-cream">
       {/* Hero image */}
       <div className="relative h-[55vh] w-full overflow-hidden">
         <img
-          src={post.image}
+          src={sanityImageUrl(post.image, { w: 1600 })}
+          srcSet={buildSrcSet(post.image, HERO_WIDTHS)}
+          sizes="100vw"
+          width={heroDims?.width}
+          height={heroDims?.height}
           alt={post.title}
           fetchPriority="high"
           decoding="async"


### PR DESCRIPTION
## Summary

Adds responsive image variants for journal images served from Sanity so phones download phone-sized images, desktops download desktop-sized ones, and modern browsers get WebP/AVIF via Sanity's `auto=format` content negotiation. Targets the LCP and bandwidth concerns called out in #55.

## How it works

New helper at [src/lib/imageUrl.ts](src/lib/imageUrl.ts):

- `sanityImageUrl(url, opts)` — appends `w` / `q` / `fit` / `auto=format` query params; passes through non-Sanity URLs unchanged
- `buildSrcSet(url, widths)` — emits a `srcSet` string covering the widths; returns `undefined` for non-Sanity URLs so React drops the attribute (otherwise the browser would just see the same static URL repeated at every density)
- `parseSanityDimensions(url)` — pulls intrinsic `width`/`height` from the Sanity asset path (`...-1600x1067.jpg`) so the `<img>` tag reserves layout space before bytes arrive (CLS defense layered on top of the existing aspect-ratio containers)

Wired into the three image surfaces:

| Surface | Strategy |
|---|---|
| BlogIndex featured post | `srcSet` covering 400→1600w, `sizes=\"(min-width: 768px) 30vw, 100vw\"`, keeps `fetchPriority=\"high\"` (LCP candidate) |
| BlogIndex post cards | `srcSet` covering 400→1200w, `sizes=\"(min-width: 768px) 45vw, 100vw\"`, keeps `loading=\"lazy\"` (below fold) |
| BlogPost hero | `srcSet` covering 600→2000w, `sizes=\"100vw\"`, keeps `fetchPriority=\"high\"` (LCP on article page) |

## Scope decisions (called out in #55 review with user)

- **Sanity-only optimization**. Static `/photos/*.jpg` fallback images stay as single-src. Reason: they are placeholder/resilience assets that Sanity replaces in production. Building a responsive pipeline for them would mean adding a Vite image plugin — meaningful infra for files that aren't the live UX.
- **Body content images out of scope**. The PortableText renderer in [BlogPost.tsx](src/pages/BlogPost.tsx) has no `image` block handler today. When Amanda starts inlining images in posts, we'll add a renderer + responsive treatment then.

## Test plan

- [x] `npm run lint` ✓
- [x] `npm run build` ✓
- [x] Verified `parseSanityDimensions` regex against a typical Sanity URL (`...-1600x1067.jpg` → `{ width: 1600, height: 1067 }`) and confirmed it doesn't false-match against static `/photos/pt2.jpg`
- [ ] After merge: run a Lighthouse pass on a Sanity-populated journal page (mobile, throttled 3G) and confirm LCP < 2.5s, CLS = 0
- [ ] After merge: open DevTools Network panel on the journal index, confirm post card images are served as WebP at appropriate widths

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)