### PR TITLE
Ignore .playwright-mcp review artifacts (#74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 *.log
 dist/
 .env
+
+# Playwright MCP review artifacts (console logs + page snapshots)
+.playwright-mcp/


### PR DESCRIPTION
## Summary

Adds `.playwright-mcp/` to `.gitignore`. The Playwright MCP server writes console logs and page snapshots there during agent-driven PR review smoke tests; those are tooling output, not source.

## Why

`gh pr create` has been warning about uncommitted changes on every recent PR because of this directory. With this change the working tree stays clean after review runs.

## Test plan

- [x] Confirmed `.playwright-mcp/` exists locally and is now ignored (`git status` shows nothing untracked after the change)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)