### PR TITLE
Center first mobile carousel cards in Services and Testimonials

### DIFF
--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -100,7 +100,7 @@ function ServiceCard({
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ delay: index * 0.15, duration: 0.6, ease: "easeOut" }}
-      className="relative shrink-0 w-[85vw] md:w-auto h-[640px] md:h-[700px] snap-start md:snap-align-none rounded-2xl overflow-hidden cursor-pointer shadow-xl"
+      className="relative shrink-0 w-[85vw] md:w-auto h-[640px] md:h-[700px] snap-center md:snap-align-none rounded-2xl overflow-hidden cursor-pointer shadow-xl"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
@@ -198,15 +198,17 @@ export default function Services() {
       </div>
 
       {/* Service Cards: horizontal scroll on mobile, grid on desktop.
-          The negative margin lets cards flow to the screen edge while
-          the section keeps its px-6 padding for everything else. */}
+          The negative margin lets cards flow to the screen edge; the
+          symmetric 7.5vw inset (= (100vw - 85vw card)/2) keeps the
+          snap-centered card balanced in the viewport on mobile. Desktop
+          resets to the section's own padding via md:px-0. */}
       <div
         ref={ref}
         className="flex md:grid md:grid-cols-3 gap-6
           overflow-x-auto md:overflow-visible
           snap-x snap-mandatory md:snap-none
           scrollbar-hide
-          -mx-6 md:mx-0 px-6 md:px-0
+          -mx-6 md:mx-0 px-[7.5vw] md:px-0
           pb-2 md:pb-0"
       >
         {services.map((service, i) => (

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -62,14 +62,17 @@ export default function Testimonials() {
         </div>
       </motion.div>
 
-      {/* Mobile: horizontal scroll. Desktop: 3-col grid. */}
+      {/* Mobile: horizontal scroll. Desktop: 3-col grid.
+          Symmetric 7.5vw inset (= (100vw - 85vw card)/2) keeps the
+          snap-centered card balanced in the viewport on mobile; the
+          negative margin lets cards reach the screen edge. */}
       <div
         ref={ref}
         className="flex md:grid md:grid-cols-3 gap-8
           overflow-x-auto md:overflow-visible
           snap-x snap-mandatory md:snap-none
           scrollbar-hide
-          -mx-6 md:mx-0 px-6 md:px-0
+          -mx-6 md:mx-0 px-[7.5vw] md:px-0
           pb-2 md:pb-0"
       >
         {testimonials.map((t, i) => (
@@ -86,7 +89,7 @@ export default function Testimonials() {
               stiffness: 280,
               damping: 20,
             }}
-            className="shrink-0 w-[85vw] md:w-auto snap-start md:snap-align-none
+            className="shrink-0 w-[85vw] md:w-auto snap-center md:snap-align-none
               bg-femme-cream border border-femme-pink/40 p-8 flex flex-col gap-6 rounded-2xl shadow-sm cursor-default"
           >
             {/* Decorative quote mark */}

--- a/src/lib/useCarouselIndex.ts
+++ b/src/lib/useCarouselIndex.ts
@@ -44,8 +44,17 @@ export function useCarouselIndex<T extends HTMLElement = HTMLDivElement>(
     const prefersReducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
+    // Center the target card in the scrollport so dot navigation lands on
+    // the same position a swipe produces with `scroll-snap-align: center`.
+    // `offsetLeft` is measured from the shared offset parent, so subtracting
+    // the container's own offset yields the card's left edge within the
+    // scroll content; the half-leftover term then centers it. Clamp to the
+    // valid scroll range so the first/last cards don't try to overscroll.
+    const center =
+      card.offsetLeft - el.offsetLeft - (el.clientWidth - card.clientWidth) / 2;
+    const maxScroll = el.scrollWidth - el.clientWidth;
     el.scrollTo({
-      left: card.offsetLeft - el.offsetLeft,
+      left: Math.max(0, Math.min(center, maxScroll)),
       behavior: prefersReducedMotion ? "auto" : "smooth",
     });
   };


### PR DESCRIPTION
## Summary

On mobile, the first card in the **Services** and **Testimonials** carousels was pinned hard against the left edge instead of feeling centered. This was caused by `scroll-snap-align: start` combined with a `px-6` bleed container — the snapped card aligned to the left of the scrollport, leaving all the slack on the right.

This PR makes both carousels center the active card with balanced side spacing.

Closes #76

## Changes

- **`src/components/Services.tsx`** — card `snap-start` → `snap-center`; carousel container `px-6` → `px-[7.5vw]` on mobile.
- **`src/components/Testimonials.tsx`** — same two changes.
- **`src/lib/useCarouselIndex.ts`** — `scrollToIndex` now centers the target card in the scrollport (clamped to the valid scroll range) so dot navigation lands on the same centered position a swipe produces.

### Why `px-[7.5vw]`
Cards are `w-[85vw]`. To center an 85vw card in a full-bleed (`-mx-6`) track, each side needs `(100vw − 85vw) / 2 = 7.5vw` of inset. This also gives the first and last cards the room to reach a centered snap position. Desktop is fully untouched (`md:px-0`, `md:snap-align-none`, `md:grid`).

## Visual assessment (Playwright, iPhone-sized 390px viewport)

Measured the active card's left vs. right gap inside the full-bleed carousel track. Balanced = `leftGap ≈ rightGap`.

**Services**
| State | Before (leftGap / rightGap) | After (leftGap / rightGap) |
|-------|------|------|
| Initial (card 1) | 0px / 59px ❌ jammed left | **29px / 29px** ✅ centered |
| Dot 2 (card 2) | 0px / 59px | 29px / 30px ✅ |
| Dot 3 (card 3) | 34px / 25px | 29px / 29px ✅ |

**Testimonials**
| State | Before (leftGap / rightGap) | After (leftGap / rightGap) |
|-------|------|------|
| Initial (card 1) | 0px / 59px ❌ jammed left | **29px / 29px** ✅ centered |
| Dot 2 (card 2) | 0px / 59px | 29px / 30px ✅ |
| Dot 3 (card 3) | 34px / 25px | 29px / 29px ✅ |

- First card now sits centered with symmetric side spacing in both sections; neighbors peek symmetrically.
- Swipe snapping and dot navigation both land on the centered position.

## Note on page-level horizontal overflow (corrected)

An earlier revision of this description claimed "no page-level horizontal overflow." That was wrong — it came from a flawed check that compared against an emulation-inflated `window.innerWidth` (417px) instead of the real client width. Thanks @sabnanikl-dev / Codex for catching it.

After re-measuring honestly (no mobile emulation; comparing `documentElement.scrollWidth` to `clientWidth`, and excluding elements clipped by an `overflow-x` ancestor):

- **The carousel changes introduce no page overflow.** Both carousel tracks are `overflow-x-auto`; their off-screen cards are clipped and do not contribute to document scroll width. No element from the three files in this PR appears among the page-overflow offenders.
- **There is a ~26px pre-existing horizontal overflow** at mobile widths, from `About.tsx`'s entry transform (`initial={{ x: 50 }}` on the text column, rendering at `left=74`, `right=401` vs a 375px viewport), plus a minor ~3px vendor-list item. **Identical numbers measured on `main` and on this branch**, confirming it is not introduced here.

This is out of scope for issue #76 (different section, different files) and is now tracked separately in **#79**.

## Acceptance criteria
- [x] First Services card visually centered/balanced on mobile initial load
- [x] First Testimonials card visually centered/balanced on mobile initial load
- [x] Swipe/scroll snapping lands cards in the centered position
- [x] Dot navigation scrolls to the correct (centered) card in both sections
- [x] Desktop Services grid unchanged
- [x] Desktop Testimonials grid unchanged
- [x] No page-level horizontal overflow **introduced by this PR** (a pre-existing ~26px overflow from About exists on `main` and is tracked in #79)
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Visual assessment performed with browser automation at ~390px (and 375px for the overflow audit)
- [x] Before/after notes included (geometry table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)