### PR TITLE
Fix mobile horizontal overflow

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -2,7 +2,7 @@ import { motion } from "motion/react";
 
 export default function About() {
   return (
-    <section id="about" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-[2fr_3fr] gap-12 md:gap-16 items-center">
+    <section id="about" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-[2fr_3fr] gap-12 md:gap-16 items-center overflow-x-clip">
       <motion.div
         initial={{ opacity: 0, x: -50 }}
         whileInView={{ opacity: 1, x: 0 }}

--- a/src/components/Vendors.tsx
+++ b/src/components/Vendors.tsx
@@ -39,7 +39,7 @@ function VendorCard({
       role="button"
       tabIndex={0}
       aria-label={`Open ${vendor.name} details`}
-      className="group flex items-center justify-between gap-3 bg-femme-cream/60 border border-femme-pink/30 px-5 py-3.5 rounded-xl
+      className="group flex w-full max-w-full box-border items-center justify-between gap-3 bg-femme-cream/60 border border-femme-pink/30 px-5 py-3.5 rounded-xl
         hover:bg-femme-cream hover:border-femme-plum/40 transition-colors duration-200
         cursor-pointer
         focus:outline-none focus:ring-2 focus:ring-femme-orange focus:ring-offset-2 focus:ring-offset-femme-cream"
@@ -101,7 +101,7 @@ export default function Vendors() {
 
       {/* Category Grid */}
       {categories.length > 0 ? (
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-10">
+        <div className="grid grid-cols-[minmax(0,1fr)] md:grid-cols-2 lg:grid-cols-3 gap-10 min-w-0">
           {categories.map((cat, catIndex) => (
             <motion.div
               key={cat.label}
@@ -109,12 +109,13 @@ export default function Vendors() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: catIndex * 0.1, duration: 0.5, ease: "easeOut" }}
+              className="min-w-0"
             >
               <h3 className="text-2xl text-femme-plum font-balgin mb-4 flex items-center gap-3">
                 <span className="w-2 h-2 rounded-full bg-femme-orange shrink-0" />
                 {cat.label}
               </h3>
-              <ul className="flex flex-col gap-3">
+              <ul className="flex flex-col gap-3 min-w-0 max-w-full">
                 {cat.vendors.map((vendor, i) => (
                   <VendorCard
                     key={vendor.name}


### PR DESCRIPTION
## Summary

Closes #79.

Fixes the mobile document-level horizontal overflow that appeared at narrow widths:

- Clips the About section's horizontal entrance transform so its off-canvas initial state does not expand the page scroll width.
- Constrains the vendor category grid to a real mobile `minmax(0, 1fr)` column and keeps vendor cards inside that column.

## Visual QA

Browser automation at mobile widths:

| Viewport | Result |
|---|---|
| ~375px | `documentElement.scrollWidth <= clientWidth` / overflow `0` |
| ~390px | `documentElement.scrollWidth <= clientWidth` / overflow `0` |

Vendor rows now fit within the section content width at both tested mobile sizes.

## Verification

- [x] `npm run lint`
- [x] `npm run build` (passes with the existing Vite chunk-size warning)
