### PR TITLE
feat: privacy-conscious analytics + CTA event tracking (#15)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,18 @@ VITE_FORMSPREE_ENDPOINT=
 VITE_SANITY_PROJECT_ID=
 VITE_SANITY_DATASET=production
 VITE_SANITY_API_VERSION=2024-01-01
+
+# Analytics (issue #15) — privacy-conscious. Provider-agnostic: set EITHER
+# Plausible OR GA4 (or both). Leave all three unset to disable analytics
+# entirely — no script loads and all tracking calls become silent no-ops.
+# See docs/analytics.md for setup. These IDs are public, but keep them in
+# env/Vercel rather than hardcoded.
+
+# Plausible (preferred — no cookie banner, no PII). Set to the site domain
+# registered in Plausible, e.g. femmeevents.com
+VITE_PLAUSIBLE_DOMAIN=
+# Optional: only for self-hosted Plausible. Defaults to https://plausible.io
+VITE_PLAUSIBLE_API_HOST=
+
+# Google Analytics 4 (fallback). Measurement ID, format G-XXXXXXXXXX
+VITE_GA4_MEASUREMENT_ID=

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,59 @@
+# Analytics (issue #15)
+
+Privacy-conscious analytics for the Femme Events site. The implementation is
+**provider-agnostic**: it supports **Plausible** and/or **Google Analytics 4**,
+chosen entirely by which environment variables are set. With none set, analytics
+is fully disabled — no script is injected and every tracking call is a silent
+no-op. No personally identifiable information (names, emails, phone numbers,
+event dates, message text) is ever sent.
+
+All logic lives in [`src/lib/analytics.ts`](../src/lib/analytics.ts):
+`initAnalytics()` (called once in `main.tsx`), `trackEvent(name, props)`, and
+`trackPageview(path)` (GA4-only; Plausible auto-tracks SPA navigations).
+
+## Environment variables
+
+| Variable | Required | Notes |
+|---|---|---|
+| `VITE_PLAUSIBLE_DOMAIN` | for Plausible | Site/data-domain registered in Plausible, e.g. `femmeevents.com` |
+| `VITE_PLAUSIBLE_API_HOST` | no | Only for self-hosted Plausible. Defaults to `https://plausible.io` |
+| `VITE_GA4_MEASUREMENT_ID` | for GA4 | Measurement ID, format `G-XXXXXXXXXX` |
+
+`VITE_*` vars are inlined into the client bundle at build time, so they must be
+set in Vercel **before** the production build runs.
+
+## Setup (Karan)
+
+Pick one provider (Plausible is recommended — no cookie banner needed).
+
+### Option A — Plausible (recommended)
+1. Create an account at <https://plausible.io> and add the site `femmeevents.com`.
+2. In Vercel → Project → Settings → Environment Variables, add
+   `VITE_PLAUSIBLE_DOMAIN=femmeevents.com` (Production, and Preview if desired).
+3. Redeploy. Pageviews and events start flowing to the Plausible dashboard.
+
+### Option B — Google Analytics 4
+1. Create a GA4 property and copy its Measurement ID (`G-XXXXXXXXXX`).
+2. In Vercel, add `VITE_GA4_MEASUREMENT_ID=G-XXXXXXXXXX`.
+3. Redeploy. Note: GA4 sets cookies — a consent banner may be required later for
+   GDPR/CCPA compliance.
+
+To verify, open the deployed site, then check the provider's realtime dashboard
+and the browser Network tab for the analytics request.
+
+## Tracked events
+
+Page views are automatic (Plausible: built-in incl. SPA routes; GA4: sent on each
+route change). Custom events:
+
+| Event | Props | Fired when |
+|---|---|---|
+| `cta_inquiry_click` | `location` (`hero`/`service_card`/`process`/`vendors`/`faq`), `service` (service-card only) | Any "Let's Chat" / "Book Now" / section inquiry CTA |
+| `nav_inquiry_click` | `location` (`nav_desktop`/`nav_mobile`) | Navbar "Inquiry" link |
+| `inquiry_submit` | `location` (`inquiry_form`) | Inquiry form submitted successfully |
+| `instagram_click` | `location` (`hero`/`footer`) | Instagram link |
+| `email_click` | `location` (`footer`) | `mailto:` link |
+| `phone_click` | `location` (`footer`) | `tel:` link |
+| `vendor_link_click` | `type` (`website`/`instagram`), `vendor` (vendor name) | Link in the vendor overlay card |
+
+Event props carry only safe metadata — never visitor-entered contents.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Suspense, lazy } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Suspense, lazy, useEffect } from "react";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
+import { trackPageview } from "./lib/analytics";
 import Navbar from "./components/Navbar";
 import Footer from "./components/Footer";
 import Hero from "./components/Hero";
@@ -21,6 +22,16 @@ import Inquiry from "./components/Inquiry";
 const BlogIndex = lazy(() => import("./pages/BlogIndex"));
 const BlogPost = lazy(() => import("./pages/BlogPost"));
 const WhatHappensNextPage = lazy(() => import("./pages/WhatHappensNext"));
+
+// Records an SPA pageview on each route change (GA4 only — Plausible's script
+// auto-captures History API navigations). Rendered inside BrowserRouter.
+function RouteAnalytics() {
+  const location = useLocation();
+  useEffect(() => {
+    trackPageview(location.pathname + location.search);
+  }, [location.pathname, location.search]);
+  return null;
+}
 
 function Home() {
   return (
@@ -40,6 +51,7 @@ function Home() {
 export default function App() {
   return (
     <BrowserRouter>
+      <RouteAnalytics />
       <Navbar />
       <Suspense fallback={<div className="min-h-screen bg-femme-cream" />}>
         <Routes>

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { Plus, Minus } from "lucide-react";
+import { trackEvent } from "../lib/analytics";
 
 const faqs = [
   {
@@ -99,6 +100,7 @@ export default function FAQ() {
           </p>
           <a
             href="#inquiry"
+            onClick={() => trackEvent("cta_inquiry_click", { location: "faq" })}
             className="inline-block mt-8 bg-femme-plum text-white px-8 py-3.5 rounded-full font-bold text-sm uppercase tracking-widest shadow-md hover:bg-femme-dark transition-colors duration-200 font-system"
           >
             Ask Us Directly

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,5 @@
+import { trackEvent } from "../lib/analytics";
+
 export default function Footer() {
   return (
     <footer className="py-10 px-6 md:px-24 bg-femme-pale border-t border-femme-plum/10">
@@ -23,12 +25,14 @@ export default function Footer() {
           <div className="text-base leading-relaxed font-system">
             <a
               href="mailto:amanda@femmeevents.com"
+              onClick={() => trackEvent("email_click", { location: "footer" })}
               className="hover:text-femme-plum transition-colors duration-200 block"
             >
               amanda@femmeevents.com
             </a>
             <a
               href="tel:6786445257"
+              onClick={() => trackEvent("phone_click", { location: "footer" })}
               className="hover:text-femme-plum transition-colors duration-200 block mt-1"
             >
               (678) 644-5257
@@ -37,6 +41,7 @@ export default function Footer() {
               href="https://instagram.com/_femmeevents"
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => trackEvent("instagram_click", { location: "footer" })}
               className="hover:text-femme-plum transition-colors duration-200 block mt-1"
             >
               @_femmeevents

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,4 +1,5 @@
 import { motion } from "motion/react";
+import { trackEvent } from "../lib/analytics";
 
 export default function Hero() {
   return (
@@ -43,6 +44,7 @@ export default function Hero() {
         >
           <motion.a
             href="#inquiry"
+            onClick={() => trackEvent("cta_inquiry_click", { location: "hero" })}
             whileHover={{ scale: 1.05, backgroundColor: "var(--color-femme-deep)", boxShadow: "0 8px 28px rgba(131,22,84,0.5)" }}
             whileTap={{ scale: 0.97 }}
             transition={{ duration: 0.2, ease: "easeOut" }}
@@ -76,6 +78,7 @@ export default function Hero() {
             href="https://www.instagram.com/_femmeevents/?hl=en"
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() => trackEvent("instagram_click", { location: "hero" })}
             className="text-base md:text-xl font-medium drop-shadow-md hover:opacity-70 transition-opacity duration-200"
           >
             <span style={{ fontFamily: 'system-ui, sans-serif' }}>@_</span>femmeevents

--- a/src/components/Inquiry.tsx
+++ b/src/components/Inquiry.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+import { trackEvent } from "../lib/analytics";
 
 const labelClass = "text-xs uppercase tracking-widest font-bold opacity-60 font-system";
 const inputClass =
@@ -47,6 +48,8 @@ export default function Inquiry() {
       if (res.ok) {
         setState("success");
         form.reset();
+        // Conversion signal only — no form-field contents are ever sent.
+        trackEvent("inquiry_submit", { location: "inquiry_form" });
       } else {
         throw new Error(`Server responded with ${res.status}`);
       }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { NavLink, useLocation } from "react-router-dom";
 import { Menu, X } from "lucide-react";
+import { trackEvent } from "../lib/analytics";
 
 export default function Navbar() {
   const [scrolled, setScrolled] = useState(false);
@@ -126,7 +127,13 @@ export default function Navbar() {
           >
             Journal
           </NavLink>
-          <a href={anchor("#inquiry")} className={linkClass}>Inquiry</a>
+          <a
+            href={anchor("#inquiry")}
+            onClick={() => trackEvent("nav_inquiry_click", { location: "nav_desktop" })}
+            className={linkClass}
+          >
+            Inquiry
+          </a>
         </div>
 
         {/* Mobile hamburger toggle */}
@@ -177,7 +184,16 @@ export default function Navbar() {
               <NavLink to="/journal" onClick={closeMenu} className={mobileLinkClass}>
                 Journal
               </NavLink>
-              <a href={anchor("#inquiry")} onClick={closeMenu} className={mobileLinkClass}>Inquiry</a>
+              <a
+                href={anchor("#inquiry")}
+                onClick={() => {
+                  closeMenu();
+                  trackEvent("nav_inquiry_click", { location: "nav_mobile" });
+                }}
+                className={mobileLinkClass}
+              >
+                Inquiry
+              </a>
             </motion.div>
           </>
         )}

--- a/src/components/Process.tsx
+++ b/src/components/Process.tsx
@@ -1,6 +1,7 @@
 import { motion } from "motion/react";
 import CarouselDots from "./CarouselDots";
 import { useCarouselIndex } from "../lib/useCarouselIndex";
+import { trackEvent } from "../lib/analytics";
 
 const steps = [
   {
@@ -123,6 +124,7 @@ export default function Process() {
       >
         <a
           href="#inquiry"
+          onClick={() => trackEvent("cta_inquiry_click", { location: "process" })}
           className="inline-block bg-femme-plum text-white px-10 py-4 rounded-full font-bold text-sm uppercase tracking-widest shadow-md hover:bg-femme-dark transition-colors duration-200 font-system"
         >
           Start Your Journey

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import CarouselDots from "./CarouselDots";
 import { useCarouselIndex } from "../lib/useCarouselIndex";
+import { trackEvent } from "../lib/analytics";
 
 const services = [
   {
@@ -167,6 +168,7 @@ function ServiceCard({
         {/* Book Now button — links to inquiry section */}
         <motion.a
           href="#inquiry"
+          onClick={() => trackEvent("cta_inquiry_click", { location: "service_card", service: service.title })}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
           aria-label={`Book ${service.title} — jump to inquiry form`}

--- a/src/components/Vendors.tsx
+++ b/src/components/Vendors.tsx
@@ -8,6 +8,7 @@ import {
 } from "../lib/vendors";
 import { vendorCategories as fallbackCategories } from "../data/vendors";
 import VendorOverlayCard from "./ui/VendorOverlayCard";
+import { trackEvent } from "../lib/analytics";
 
 interface SelectedVendor {
   vendor: Vendor;
@@ -151,6 +152,7 @@ export default function Vendors() {
         </p>
         <a
           href="#inquiry"
+          onClick={() => trackEvent("cta_inquiry_click", { location: "vendors" })}
           className="inline-block px-8 py-3.5 text-sm font-bold uppercase tracking-widest font-system
             bg-femme-plum text-white border-2 border-femme-plum
             hover:bg-femme-mauve hover:border-femme-mauve

--- a/src/components/ui/VendorOverlayCard.tsx
+++ b/src/components/ui/VendorOverlayCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { motion } from "motion/react";
 import { ExternalLink, Instagram, X } from "lucide-react";
 import { instagramUrl } from "../../lib/vendors";
+import { trackEvent } from "../../lib/analytics";
 
 interface VendorOverlayCardProps {
   name: string;
@@ -147,6 +148,7 @@ export default function VendorOverlayCard({
                 href={websiteLink}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() => trackEvent("vendor_link_click", { type: "website", vendor: name })}
                 className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full
                   bg-femme-plum text-white text-sm font-bold uppercase tracking-widest font-system
                   hover:bg-femme-deep transition-colors duration-200
@@ -161,6 +163,7 @@ export default function VendorOverlayCard({
                 href={igLink}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() => trackEvent("vendor_link_click", { type: "instagram", vendor: name })}
                 className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full
                   bg-femme-pale text-femme-plum text-sm font-bold uppercase tracking-widest font-system
                   border border-femme-plum/20

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,109 @@
+/**
+ * Privacy-conscious analytics (issue #15).
+ *
+ * Provider-agnostic: supports Plausible and/or Google Analytics 4, selected
+ * purely by which env vars are set. With none set, analytics is fully disabled —
+ * no script is injected and every call is a silent no-op. No personally
+ * identifiable information is ever sent; callers pass only safe metadata
+ * (location, link type, service name).
+ *
+ *   VITE_PLAUSIBLE_DOMAIN     site/data-domain registered in Plausible
+ *   VITE_PLAUSIBLE_API_HOST   optional; self-hosted host (default https://plausible.io)
+ *   VITE_GA4_MEASUREMENT_ID   GA4 measurement id, format G-XXXXXXXXXX
+ */
+
+type EventProps = Record<string, string | number | boolean>;
+
+declare global {
+  interface Window {
+    plausible?: ((event: string, options?: { props?: EventProps; callback?: () => void }) => void) & {
+      q?: unknown[];
+    };
+    gtag?: (...args: unknown[]) => void;
+    dataLayer?: unknown[];
+  }
+}
+
+const PLAUSIBLE_DOMAIN = import.meta.env.VITE_PLAUSIBLE_DOMAIN || "";
+const PLAUSIBLE_API_HOST = import.meta.env.VITE_PLAUSIBLE_API_HOST || "https://plausible.io";
+const GA4_ID = import.meta.env.VITE_GA4_MEASUREMENT_ID || "";
+
+const plausibleEnabled = Boolean(PLAUSIBLE_DOMAIN);
+const ga4Enabled = Boolean(GA4_ID);
+
+function appendScript(src: string, attrs: Record<string, string> = {}) {
+  const script = document.createElement("script");
+  script.src = src;
+  script.async = true;
+  script.defer = true;
+  for (const [key, value] of Object.entries(attrs)) {
+    script.setAttribute(key, value);
+  }
+  document.head.appendChild(script);
+}
+
+function initPlausible() {
+  // Queue stub so trackEvent() calls before the script loads aren't lost.
+  window.plausible =
+    window.plausible ||
+    function (...args: unknown[]) {
+      (window.plausible!.q = window.plausible!.q || []).push(args);
+    };
+  // script.js auto-captures pageviews, including SPA History API navigations.
+  appendScript(`${PLAUSIBLE_API_HOST}/js/script.js`, { "data-domain": PLAUSIBLE_DOMAIN });
+}
+
+function initGa4() {
+  window.dataLayer = window.dataLayer || [];
+  window.gtag =
+    window.gtag ||
+    function (...args: unknown[]) {
+      window.dataLayer!.push(args);
+    };
+  appendScript(`https://www.googletagmanager.com/gtag/js?id=${GA4_ID}`);
+  window.gtag("js", new Date());
+  // Disable auto pageview; SPA route changes are sent manually via trackPageview.
+  window.gtag("config", GA4_ID, { send_page_view: false });
+}
+
+/** Inject configured provider scripts. Safe to call once at app startup. */
+export function initAnalytics() {
+  if (typeof window === "undefined") return;
+  try {
+    if (plausibleEnabled) initPlausible();
+    if (ga4Enabled) initGa4();
+  } catch {
+    // Analytics must never break the app.
+  }
+}
+
+/** Fire a custom event to whichever provider(s) are configured. No-op otherwise. */
+export function trackEvent(name: string, props?: EventProps) {
+  try {
+    if (plausibleEnabled) {
+      window.plausible?.(name, props ? { props } : undefined);
+    }
+    if (ga4Enabled) {
+      window.gtag?.("event", name, props ?? {});
+    }
+  } catch {
+    // Never let a tracking call interrupt a click or submit.
+  }
+}
+
+/**
+ * Record a pageview for an SPA route change. GA4 only — Plausible's script.js
+ * auto-captures History API navigations, so sending it here would double count.
+ */
+export function trackPageview(path?: string) {
+  if (!ga4Enabled) return;
+  try {
+    window.gtag?.("event", "page_view", {
+      page_path: path ?? window.location.pathname,
+      page_location: window.location.href,
+      page_title: document.title,
+    });
+  } catch {
+    // No-op on failure.
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import {StrictMode} from 'react';
 import {createRoot} from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import {initAnalytics} from './lib/analytics.ts';
+
+initAnalytics();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,9 @@ interface ImportMetaEnv {
   readonly VITE_SANITY_PROJECT_ID?: string;
   readonly VITE_SANITY_DATASET?: string;
   readonly VITE_SANITY_API_VERSION?: string;
+  readonly VITE_PLAUSIBLE_DOMAIN?: string;
+  readonly VITE_PLAUSIBLE_API_HOST?: string;
+  readonly VITE_GA4_MEASUREMENT_ID?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Closes #15

## Summary

Adds a **provider-agnostic** analytics layer for the site. It supports **Plausible** and/or **GA4**, selected purely by which `VITE_` env vars are set. With none set, **no script loads and every tracking call is a silent no-op** — satisfying the "fail gracefully" requirement. **No PII is ever sent**; event props carry only safe metadata (location, link type, vendor business name).

Provider choice was confirmed as provider-agnostic so Karan can pick/pay for an account later and it "just works" by setting one env var in Vercel.

## What changed

- **`src/lib/analytics.ts`** (new) — the whole surface: `initAnalytics()`, `trackEvent(name, props)`, `trackPageview(path)`. Plausible's `script.js` auto-captures pageviews incl. SPA History API navigations; GA4 has auto pageview disabled and gets a manual `page_view` on route change (no double counting).
- **`src/main.tsx`** — calls `initAnalytics()` once at startup.
- **`src/App.tsx`** — `RouteAnalytics` fires `trackPageview` on route change.
- **CTA/link instrumentation** (additive `onClick`s, nothing blocks navigation):
  - `cta_inquiry_click` — Hero, Services (per-card w/ `service`), Process, Vendors, FAQ
  - `nav_inquiry_click` — Navbar desktop + mobile
  - `inquiry_submit` — on successful form submit (no field contents sent)
  - `instagram_click` (Hero, Footer), `email_click`, `phone_click` (Footer)
  - `vendor_link_click` — vendor overlay website/instagram links
- **Config/docs** — `.env.example` + `src/vite-env.d.ts` document the 3 new vars; `docs/analytics.md` has the full setup guide + event reference.

## Acceptance criteria

- [x] Provider selected/documented (provider-agnostic; see `docs/analytics.md`)
- [x] Provider ID/domain from env, not hardcoded
- [x] Page views tracked in production (Plausible auto / GA4 manual on route change)
- [x] Key CTA clicks tracked with consistent lowercase event names
- [x] No PII sent to analytics
- [x] Fails gracefully when env/config missing
- [x] No noticeable performance regression (scripts `async`/`defer`, injected after render)
- [x] `npm run lint` passes
- [x] `npm run build` passes

## Verification done

- `npm run lint` (tsc) ✅ and `npm run build` ✅
- Dev server boots cleanly with analytics enabled; confirmed Vite inlines the env vars and the `plausibleEnabled`/`ga4Enabled` gating resolves correctly.
- ⚠️ Browser-level network-payload verification (event fires, no PII in transit) was **not** run — no headless browser is available in this environment. Recommend confirming via the provider's realtime dashboard after the env var is set (the real end-to-end check anyway).

## ⚙️ Setup steps Karan must complete

Pick **one** provider (Plausible recommended — no cookie banner needed):

**Plausible:** create the site `femmeevents.com` at plausible.io → in Vercel set `VITE_PLAUSIBLE_DOMAIN=femmeevents.com` → redeploy.

**GA4:** create a GA4 property → in Vercel set `VITE_GA4_MEASUREMENT_ID=G-XXXXXXXXXX` → redeploy. (Note: GA4 sets cookies — a consent banner may be needed later.)

`VITE_*` vars are inlined at build time, so they must be set in Vercel **before** the production build runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)