### PR TITLE
content: update homepage About copy to Amanda-approved draft

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,5 +1,12 @@
 import { motion } from "motion/react";
 
+const aboutParagraphs = [
+  `As women, we're told a wedding is supposed to be the "most important day of our lives." And listen, we know life has plenty of other milestones worth screaming about: the promotion, the degree, the first home, the babies if you want them, the version of yourself you worked hard to become.`,
+  `But a wedding is still pretty damn cool.`,
+  `It might be the one time all of your people are in the same room. The moment two lives, two families, and sometimes two cultures get woven together in front of everyone who loves you. It is emotional. It is chaotic. It is kind of a big deal.`,
+  `And we love the girlhood of it all: the dresses, makeup, heels, glitter, lashes, perfume, happy tears, group chats, moms, grandmothers, sisters, and girlfriends showing up with overwhelming love. It is such a feminine, personal, once-in-a-lifetime kind of energy, and Femme Events exists to protect that feeling while making sure the logistics do not eat it alive.`,
+];
+
 export default function About() {
   return (
     <section id="about" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-[2fr_3fr] gap-12 md:gap-16 items-center overflow-x-clip">
@@ -29,9 +36,11 @@ export default function About() {
         <h2 className="text-5xl md:text-8xl text-femme-dark leading-tight italic">
           Why We Obsess Over&nbsp;"I Do"
         </h2>
-        <p className="text-femme-dark/80 text-2xl leading-relaxed max-w-lg">
-          Look, anyone can book a ballroom. We zero in on the tiny moments—grandma's happy tears, the inside joke on the cocktail napkin, the playlist that makes cousins dance together on purpose.
-        </p>
+        <div className="flex flex-col gap-5 text-femme-dark/80 text-lg md:text-xl leading-relaxed max-w-xl">
+          {aboutParagraphs.map((paragraph, index) => (
+            <p key={index}>{paragraph}</p>
+          ))}
+        </div>
         <motion.a
           href="#services"
           whileHover={{ scale: 1.03, backgroundColor: "var(--color-femme-deep)" }}


### PR DESCRIPTION
Closes #84

## Summary
Replaces the placeholder homepage About body copy ("anyone can book a ballroom...") with the Amanda-approved "Why We Obsess Over 'I Do'" copy from the website copy intake (`docs/amanda-website-copy-draft.html`). The section structure, image, and entrance animations are preserved.

## Changes
- `src/components/About.tsx`
  - Heading unchanged ("Why We Obsess Over 'I Do'").
  - Body now renders the full 4-paragraph approved copy from a `aboutParagraphs` array (avoids JSX quote/apostrophe escaping; matches the string-data pattern used in `FAQ.tsx`/`Process.tsx`).
  - Body type scaled from `text-2xl` (single line) to `text-lg md:text-xl` with `gap-5` between paragraphs and `max-w-xl`, so multi-paragraph long-form copy reads cleanly on mobile and desktop.

## Decision: full vs. shorter copy
Used the **full** approved copy. The issue lists it as the primary "Approved homepage About copy"; the shorter variant is only a fallback "if the homepage needs less text." Readability is handled via the type-scale/spacing change rather than trimming. No "read more" link was added because the About / Brand Story page does not exist yet (separate future issue).

## Acceptance criteria
- [x] Homepage About uses Amanda-approved copy
- [x] No visible em dashes (prior em dash removed; copy contains none)
- [x] No "big day," "your day," or "weird"
- [x] Mobile + desktop layouts remain readable (responsive type scale + paragraph spacing)
- [x] `npm run lint` passes (`tsc --noEmit`)
- [x] `npm run build` passes

## Notes for reviewer
- Scope kept to `About.tsx` only. The source doc `docs/amanda-website-copy-draft.html` is present locally but left untracked — committing it isn't part of this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)