### PR TITLE
content: add About / Brand Story page with approved Femme positioning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Suspense, lazy } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Suspense, lazy, useEffect } from "react";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import Navbar from "./components/Navbar";
 import Footer from "./components/Footer";
 import Hero from "./components/Hero";
@@ -22,6 +22,31 @@ const BlogIndex = lazy(() => import("./pages/BlogIndex"));
 const BlogPost = lazy(() => import("./pages/BlogPost"));
 const WhatHappensNextPage = lazy(() => import("./pages/WhatHappensNext"));
 const AboutPage = lazy(() => import("./pages/AboutPage"));
+
+// On a full-page load (or client navigation) to a "/#section" URL, the browser
+// tries to scroll to the fragment before React has rendered the target, so the
+// scroll is lost and the page stays at the top. Re-run the scroll, retrying for
+// a few frames until the target element exists.
+function ScrollToHash() {
+  const { pathname, hash } = useLocation();
+  useEffect(() => {
+    if (!hash) return;
+    const id = hash.slice(1);
+    let raf = 0;
+    let attempts = 0;
+    const scrollToTarget = () => {
+      const el = document.getElementById(id);
+      if (el) {
+        el.scrollIntoView();
+        return;
+      }
+      if (attempts++ < 20) raf = requestAnimationFrame(scrollToTarget);
+    };
+    raf = requestAnimationFrame(scrollToTarget);
+    return () => cancelAnimationFrame(raf);
+  }, [pathname, hash]);
+  return null;
+}
 
 function Home() {
   return (
@@ -41,6 +66,7 @@ function Home() {
 export default function App() {
   return (
     <BrowserRouter>
+      <ScrollToHash />
       <Navbar />
       <Suspense fallback={<div className="min-h-screen bg-femme-cream" />}>
         <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import Inquiry from "./components/Inquiry";
 const BlogIndex = lazy(() => import("./pages/BlogIndex"));
 const BlogPost = lazy(() => import("./pages/BlogPost"));
 const WhatHappensNextPage = lazy(() => import("./pages/WhatHappensNext"));
+const AboutPage = lazy(() => import("./pages/AboutPage"));
 
 function Home() {
   return (
@@ -44,6 +45,7 @@ export default function App() {
       <Suspense fallback={<div className="min-h-screen bg-femme-cream" />}>
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/about" element={<AboutPage />} />
           <Route path="/what-happens-next" element={<WhatHappensNextPage />} />
           <Route path="/journal" element={<BlogIndex />} />
           <Route path="/journal/:slug" element={<BlogPost />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -116,7 +116,14 @@ export default function Navbar() {
             scrolled ? "text-femme-dark" : "text-white"
           }`}
         >
-          <a href={anchor("#about")} className={linkClass}>About</a>
+          <NavLink
+            to="/about"
+            className={({ isActive }) =>
+              `${linkClass}${isActive ? " opacity-60" : ""}`
+            }
+          >
+            About
+          </NavLink>
           <a href={anchor("#services")} className={linkClass}>Services</a>
           <NavLink
             to="/journal"
@@ -172,7 +179,7 @@ export default function Navbar() {
               transition={{ duration: 0.2, ease: "easeOut" }}
               className="md:hidden fixed top-20 left-4 right-4 z-50 bg-femme-cream/98 backdrop-blur-md rounded-2xl shadow-lg p-3 flex flex-col gap-1"
             >
-              <a href={anchor("#about")} onClick={closeMenu} className={mobileLinkClass}>About</a>
+              <NavLink to="/about" onClick={closeMenu} className={mobileLinkClass}>About</NavLink>
               <a href={anchor("#services")} onClick={closeMenu} className={mobileLinkClass}>Services</a>
               <NavLink to="/journal" onClick={closeMenu} className={mobileLinkClass}>
                 Journal

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,0 +1,77 @@
+import { motion } from "motion/react";
+import { Link } from "react-router-dom";
+
+const storyParagraphs = [
+  `Femme Events started with a simple frustration: weddings can feel way too obsessed with rules.`,
+  `Tradition can be beautiful, but it should feel like an option, not a strict set of instructions. Amanda built Femme for the brides, couples, and friend groups who want space to be fully themselves: cool, silly, sentimental, dramatic, hyper-feminine, alternative, non-traditional, different, or completely impossible to put in a box.`,
+  `When you work with Femme, you get someone completely in your corner. Someone calm under pressure. Someone organized enough to catch the tiny details, but flexible enough to never say, "that's not how it's usually done." Someone who will be kind to your people, kind to your vendors, and protective of the energy you want your wedding to hold.`,
+];
+
+const closingLine = `You guide the feeling. We handle everything else.`;
+
+export default function AboutPage() {
+  return (
+    <main className="min-h-screen bg-femme-cream pt-32">
+      <section className="px-6 pb-16 md:px-24 md:pb-24">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: "easeOut" }}
+          className="mx-auto max-w-3xl"
+        >
+          <Link
+            to="/"
+            className="mb-8 inline-block text-sm font-bold uppercase tracking-widest text-femme-plum transition-colors duration-200 hover:text-femme-dark font-system"
+          >
+            ← Back to home
+          </Link>
+          <p className="mb-3 text-sm font-bold uppercase tracking-[0.25em] text-femme-plum/70 font-system">
+            Our Story
+          </p>
+          <h1 className="mb-6 text-5xl italic text-femme-dark md:text-7xl">
+            For celebrations with feeling, personality, and a plan.
+          </h1>
+          <div className="h-1 w-32 bg-femme-orange" />
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-60px" }}
+          transition={{ duration: 0.6, delay: 0.1, ease: "easeOut" }}
+          className="mx-auto mt-10 flex max-w-3xl flex-col gap-6 text-lg leading-relaxed text-femme-dark/75 md:text-xl font-system"
+        >
+          {storyParagraphs.map((paragraph, index) => (
+            <p key={index}>{paragraph}</p>
+          ))}
+          <p className="mt-2 text-3xl italic leading-snug text-femme-plum md:text-4xl">
+            {closingLine}
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6, delay: 0.2, ease: "easeOut" }}
+          className="mx-auto mt-14 flex max-w-3xl flex-col gap-4 rounded-3xl bg-femme-pale/70 p-8 md:flex-row md:items-center md:justify-between"
+        >
+          <div>
+            <h2 className="text-3xl text-femme-dark font-balgin">
+              Ready when you are
+            </h2>
+            <p className="mt-2 text-femme-dark/60 font-system">
+              Tell us about your wedding and we'll take it from there.
+            </p>
+          </div>
+          <Link
+            to="/#inquiry"
+            className="inline-block rounded-full bg-femme-plum px-8 py-4 text-center text-sm font-bold uppercase tracking-widest text-white shadow-md transition-colors duration-200 hover:bg-femme-dark font-system"
+          >
+            Start Your Inquiry
+          </Link>
+        </motion.div>
+      </section>
+    </main>
+  );
+}

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -11,7 +11,7 @@ const closingLine = `You guide the feeling. We handle everything else.`;
 
 export default function AboutPage() {
   return (
-    <main className="min-h-screen bg-femme-cream pt-32">
+    <main className="min-h-screen bg-femme-lavender pt-32">
       <section className="px-6 pb-16 md:px-24 md:pb-24">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -64,12 +64,12 @@ export default function AboutPage() {
               Tell us about your wedding and we'll take it from there.
             </p>
           </div>
-          <Link
-            to="/#inquiry"
+          <a
+            href="/#inquiry"
             className="inline-block rounded-full bg-femme-plum px-8 py-4 text-center text-sm font-bold uppercase tracking-widest text-white shadow-md transition-colors duration-200 hover:bg-femme-dark font-system"
           >
             Start Your Inquiry
-          </Link>
+          </a>
         </motion.div>
       </section>
     </main>


### PR DESCRIPTION
Closes #85

## Summary
Adds a dedicated About / Brand Story page using the Amanda-approved heading and copy from the website copy intake (`docs/amanda-website-copy-draft.html`), and makes it reachable from the primary navigation.

## Changes
- **New page** `src/pages/AboutPage.tsx` at route **`/about`** (lazy-loaded, code-split into its own chunk like the other pages).
  - Modeled on the existing `WhatHappensNext` page: cream background, `pt-32` to clear the fixed navbar, plum/orange palette, "← Back to home" link, eyebrow, large italic display heading, accent divider, and a bottom CTA box linking to `/#inquiry`.
  - Approved heading: "For celebrations with feeling, personality, and a plan."
  - Approved 4-part brand story copy, with the closing line ("You guide the feeling. We handle everything else.") styled as a plum pull-quote.
  - Body prose uses `font-system` (per the in-repo convention for punctuation-heavy copy) so colons/quotes/hyphens render cleanly instead of the display font's stylized glyphs.
- **`src/App.tsx`** — register the `/about` route.
- **`src/components/Navbar.tsx`** — repurpose the existing "About" link (desktop + mobile) from the homepage `#about` anchor to the new `/about` page, using the same `NavLink` active-state pattern as the Journal link.

## Decisions for reviewer to confirm
- **Nav "About" now points to the dedicated page** rather than scrolling to the homepage `#about` section. This keeps the nav uncluttered and is the conventional IA once an About page exists. The homepage About section itself is untouched (homepage section IA intact), and this avoids editing `About.tsx` (no conflict with the open #84 PR). Easy to switch to keeping nav "About" → homepage section and surfacing the page elsewhere (e.g. footer) if preferred.
- **No photo on the page (text-driven).** The About photo is meant to be Sanity/CMS-managed, so I avoided hand-placing a static placeholder image. A CMS-driven hero image can be added in a follow-up.

## Acceptance criteria
- [x] New About / Brand Story page exists and is reachable from the site UI (navbar, desktop + mobile)
- [x] Approved heading and copy present
- [x] No visible em dashes
- [x] No "big day," "your day," or "weird"
- [x] Mobile + desktop layouts polished/readable (responsive type scale, max-w-3xl measure, established page pattern)
- [x] `npm run lint` passes (`tsc --noEmit`)
- [x] `npm run build` passes (new `AboutPage` chunk ~2.96 kB)

## Verification notes
Verified via `npm run lint` and `npm run build`. No browser/Playwright is installed locally, so visual polish was not screenshot-verified — it reuses the proven `WhatHappensNext` layout and brand tokens. Worth a quick visual check during QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)