### PR TITLE
content: update Services section with approved packages, scope, and heading (#86)

### DIFF
--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -192,21 +192,24 @@ export default function Services() {
   return (
     <section id="services" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender">
       {/* Header */}
-      <div className="mb-16 max-w-4xl">
-        <h2 className="text-4xl md:text-5xl lg:text-6xl text-femme-dark mb-6 italic font-bold leading-tight">
+      <div className="mb-16">
+        <h2 className="text-5xl md:text-8xl text-femme-dark leading-tight italic mb-6">
           For the look, the feeling, and every moving piece in between.
         </h2>
         <div className="h-1 w-32 bg-femme-orange mb-8" />
-        <p className="text-femme-dark/70 text-base md:text-lg font-system leading-relaxed mb-4">
-          Femme Events is for couples who know what they want the wedding to
-          feel like, even if they need help turning the Pinterest boards, vendor
-          emails, family opinions, and tiny moving pieces into an actual plan.
-        </p>
-        <p className="text-femme-dark/70 text-base md:text-lg font-system leading-relaxed">
-          We do not believe in “this is how it’s always done.” We believe in
-          your way, your energy, your people, and a planning process that feels
-          safe, clear, and completely supported.
-        </p>
+        <div className="max-w-3xl">
+          <p className="text-femme-dark/70 text-base md:text-lg font-system leading-relaxed mb-4">
+            Femme Events is for couples who know what they want the wedding to
+            feel like, even if they need help turning the Pinterest boards,
+            vendor emails, family opinions, and tiny moving pieces into an actual
+            plan.
+          </p>
+          <p className="text-femme-dark/70 text-base md:text-lg font-system leading-relaxed">
+            We do not believe in “this is how it’s always done.” We believe in
+            your way, your energy, your people, and a planning process that feels
+            safe, clear, and completely supported.
+          </p>
+        </div>
       </div>
 
       {/* Service Cards: horizontal scroll on mobile, grid on desktop.

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -6,49 +6,50 @@ import { trackEvent } from "../lib/analytics";
 
 const services = [
   {
-    title: "Just Show Up",
-    subtitle: "Day-of Coordination",
+    title: "In Your Corner",
+    subtitle: "Wedding Coordination",
     image: "/photos/pt3.jpg",
     alt: "Couple sharing a moment by arched window",
     includes: [
+      "Services begin six weeks before the wedding day",
       "Initial consultation + venue walkthrough",
-      "Vendor coordination (contracts, timelines, contact info)",
-      "Detailed day-of timeline",
-      "8-hour day-of coordination with 2 coordinators",
+      "Vendor coordination: contracts, timelines, and contact information",
+      "Detailed wedding timeline",
+      "All-day wedding management",
       "Rehearsal coordination",
-      "Post-wedding vendor tip management",
       "Items pickup and venue breakdown oversight",
     ],
-    note: "Add-on: Extended coverage (+4 hours) available",
+    note: null,
   },
   {
     title: "Getting It Together",
-    subtitle: "Partial Planning",
+    subtitle: "Partial Planning + Coordination",
     image: "/photos/kj1.jpg",
     alt: "Couple sharing a kiss in the car after their ceremony",
     includes: [
-      "Everything in Day-of Coordination, plus:",
-      "3–4 planning sessions (virtual or in-person)",
-      "Vendor recommendations + meeting attendance (up to 3)",
-      "Design concept development + mood boards",
-      "Budget tracking and management",
-      "Decor coordination (what to buy, where, and how to set it up)",
+      "Services begin 12 weeks before the wedding day",
+      "Everything in Wedding Coordination, plus:",
+      "3-4 planning sessions, virtual or in-person",
+      "Vendor recommendations",
+      "Vendor meeting attendance, up to 3 meetings",
+      "Decor coordination: what to source, where it goes, and how it gets set up",
     ],
     note: null,
   },
   {
     title: "The Full Femme",
-    subtitle: "Full Coordination + Design",
+    subtitle: "Full Coordination + Design Guidance",
     image: "/photos/kj2.jpg",
     alt: "Couple celebrating their grand exit through a confetti send-off",
     includes: [
-      "Everything in Partial Planning, plus:",
-      "Full design direction (color palette, mood, aesthetic guidance)",
+      "Services begin six months before the wedding day",
+      "Everything in Partial Planning + Coordination, plus:",
+      "Full design direction for the wedding's overall mood, palette, and visual story",
+      "Pinterest and mood board refinement so the inspiration turns into a cohesive design plan",
+      "Floral direction, linen selection, stationery guidance, decor notes, and styling details",
       "DIY decor sourcing + creation coordination",
-      "Unlimited planning support (text / email / Voxer)",
-      "Welcome bag + stationery design guidance",
-      "Day-after brunch coordination (if applicable)",
-      "Post-wedding social media content strategy",
+      "Unlimited planning support by call and email",
+      "High-touch coordination so the wedding feels intentional, personal, and visually pulled together",
     ],
     note: null,
   },
@@ -59,7 +60,6 @@ const addons = [
   "Welcome party coordination",
   "Decor package (setup + breakdown only)",
   "Destination wedding premium (30+ miles)",
-  "Second coordinator",
 ];
 
 function IncludesList({
@@ -192,11 +192,21 @@ export default function Services() {
   return (
     <section id="services" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender">
       {/* Header */}
-      <div className="mb-16">
-        <h2 className="text-6xl md:text-8xl lg:text-9xl text-femme-dark mb-4 italic font-bold">
-          Services That Save Sanity
+      <div className="mb-16 max-w-4xl">
+        <h2 className="text-4xl md:text-5xl lg:text-6xl text-femme-dark mb-6 italic font-bold leading-tight">
+          For the look, the feeling, and every moving piece in between.
         </h2>
-        <div className="h-1 w-32 bg-femme-orange" />
+        <div className="h-1 w-32 bg-femme-orange mb-8" />
+        <p className="text-femme-dark/70 text-base md:text-lg font-system leading-relaxed mb-4">
+          Femme Events is for couples who know what they want the wedding to
+          feel like, even if they need help turning the Pinterest boards, vendor
+          emails, family opinions, and tiny moving pieces into an actual plan.
+        </p>
+        <p className="text-femme-dark/70 text-base md:text-lg font-system leading-relaxed">
+          We do not believe in “this is how it’s always done.” We believe in
+          your way, your energy, your people, and a planning process that feels
+          safe, clear, and completely supported.
+        </p>
       </div>
 
       {/* Service Cards: horizontal scroll on mobile, grid on desktop.


### PR DESCRIPTION
## Summary
Updates the Services section to the Amanda + Karan approved copy from `docs/amanda-website-copy-draft.html`.

Closes #86

## Changes (`src/components/Services.tsx`)
- **Heading + intro**: new heading "For the look, the feeling, and every moving piece in between." plus the two approved intro paragraphs.
- **Package 1 renamed** to **In Your Corner** (subtitle: *Wedding Coordination*).
- **Service start timing** added to each package: six weeks / 12 weeks / six months before the wedding day.
- **"All-day wedding management"** replaces the "8-hour … with 2 coordinators" bullet (no coordinator count, no hour cap).
- **Design guidance** now lives only in **The Full Femme** (removed design concept/mood boards from Getting It Together).
- **Removed per scope guardrails**: budget tracking/management, post-wedding vendor tip management, welcome bag guidance, day-after brunch coordination, and post-wedding social media content strategy.
- **Removed "Second coordinator" add-on** — coordinator-count language, which the acceptance criteria forbid anywhere in the section.
- Straight hyphens only in copy (e.g. "3-4 planning sessions"); no em or en dashes in visible service copy.

## Acceptance criteria
- [x] Approved heading, intro, package names, timing, and bullets
- [x] First package named "In Your Corner"
- [x] Design guidance positioned primarily in The Full Femme
- [x] No coordinator count language
- [x] No budget management language
- [x] No visible em dashes in service copy
- [x] `npm run lint` passes (tsc --noEmit)
- [x] `npm run build` passes

## Out of scope (flagged for follow-up)
`src/components/FAQ.tsx` still mentions "extra coordinators" in an answer, and `src/data/posts.ts` (blog content) references coordinator counts. Left untouched to keep this PR to one task — worth a separate issue if coordinator-count language should be scrubbed site-wide.

## Test plan
- `npm run lint` ✅
- `npm run build` ✅
- Manual review of rendered copy against the approved draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)