### PR TITLE
content: add audience/differentiator copy near Inquiry CTA (#87)

### DIFF
--- a/src/components/Inquiry.tsx
+++ b/src/components/Inquiry.tsx
@@ -96,6 +96,29 @@ export default function Inquiry() {
   /* ──────────── Normal form ──────────── */
   return (
     <section id="inquiry" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16">
+      {/* Audience / differentiator — confidence block before the form (Issue #87) */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6, ease: "easeOut" }}
+        className="md:col-span-2 max-w-3xl mx-auto text-center"
+      >
+        <p className="text-femme-dark text-3xl md:text-4xl italic font-display leading-tight mb-8">
+          You belong here if you want the wedding to feel like you, not like a
+          checklist someone handed you.
+        </p>
+        <p className="text-femme-dark/70 text-base md:text-lg font-system leading-relaxed mb-8">
+          Bring us the disco balls, the bows, the moody florals, the dramatic
+          dress change, the sentimental ceremony, the different little detail
+          nobody else understands, the hyper-feminine fantasy, the alternative
+          mood board, the silly inside joke, the “is this too much?” idea.
+        </p>
+        <p className="text-femme-plum text-2xl md:text-3xl italic font-display">
+          It is not too much. It is the point.
+        </p>
+      </motion.div>
+
       <div className="flex flex-col gap-6">
         <h2 className="text-6xl md:text-8xl text-femme-dark leading-[0.95] italic">
           Ready to Chat Dates &amp; Dreams?

--- a/src/components/Inquiry.tsx
+++ b/src/components/Inquiry.tsx
@@ -66,7 +66,7 @@ export default function Inquiry() {
   /* ──────────── Success state ──────────── */
   if (state === "success") {
     return (
-      <section id="inquiry" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16 items-center">
+      <section id="inquiry" className="scroll-mt-24 md:scroll-mt-28 py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16 items-center">
         <div className="flex flex-col gap-6">
           <h2 className="text-6xl md:text-8xl text-femme-dark leading-[0.95] italic">
             Ready to Chat Dates &amp; Dreams?
@@ -95,7 +95,7 @@ export default function Inquiry() {
 
   /* ──────────── Normal form ──────────── */
   return (
-    <section id="inquiry" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16">
+    <section id="inquiry" className="scroll-mt-24 md:scroll-mt-28 py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16">
       {/* Audience / differentiator — confidence block before the form (Issue #87) */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
## Summary
Adds the Karan-approved "You belong here if…" audience/differentiator copy as a confidence-building block at the top of the Inquiry section, immediately before the form — clarifying who Femme is for while keeping the tone warm, direct, and slightly bold.

Closes #87

## Changes (`src/components/Inquiry.tsx`)
- New full-width (`md:col-span-2`) centered copy block as the first item in the Inquiry section grid, so it sits in the same `bg-femme-lavender` conversion zone and reads as part of the form, not a separate services block.
- Three approved paragraphs:
  - Opening line — display serif (Frunchy Sage) italic.
  - Middle "Bring us the disco balls…" list — `font-system` for clean, scannable long-form reading.
  - Kicker "It is not too much. It is the point." — display serif italic in `femme-plum` for the confidence punch.
- Added only to the normal form state (not the post-submit success state).

## Acceptance criteria
- [x] Approved copy appears near the Inquiry CTA/form
- [x] Visually connected to conversion (shares the inquiry section + background, directly above the form)
- [x] No visible em dashes in copy
- [x] No "big day," "your day," or "weird"
- [x] Mobile (single column, stacked) and desktop (spans both columns above the heading + form) layouts readable
- [x] `npm run lint` passes (tsc --noEmit)
- [x] `npm run build` passes

## Test plan
- `npm run lint` ✅
- `npm run build` ✅
- Manual review of rendered copy against the approved draft (`docs/amanda-website-copy-draft.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)