### PR TITLE
content: align Process section copy with approved service scope (#88)

### DIFF
--- a/src/components/Process.tsx
+++ b/src/components/Process.tsx
@@ -6,27 +6,27 @@ import { trackEvent } from "../lib/analytics";
 const steps = [
   {
     number: "01",
-    label: "Book",
+    label: "Inquire",
     description:
       "Fill out the inquiry form and we'll get back to you within 48 hours to schedule a free consultation call.",
   },
   {
     number: "02",
-    label: "Plan",
+    label: "Get Organized",
     description:
-      "We map out your vision — vendors, timelines, budgets, and everything in between. You make decisions; we handle the logistics.",
+      "We gather the vendor contracts, contact information, priorities, timelines, and moving pieces so nothing important is floating around in a group chat.",
   },
   {
     number: "03",
-    label: "Design",
+    label: "Shape the Look",
     description:
-      "Mood boards, color palettes, decor direction — we build the aesthetic so your day looks exactly how you dreamed it.",
+      "Mood boards, color palettes, floral notes, linens, stationery guidance, and decor direction help the aesthetic feel cohesive without forcing it into a template.",
   },
   {
     number: "04",
     label: "Celebrate",
     description:
-      "Show up, breathe, and soak it all in. We're running the show behind the scenes so you never have to.",
+      "You guide the energy. We run the timeline, vendors, setup, rehearsal, and wedding-day logistics so you can be fully present with your people.",
   },
 ];
 
@@ -50,7 +50,7 @@ export default function Process() {
         </h2>
         <div className="h-1 w-32 bg-femme-orange" />
         <p className="mt-6 text-femme-dark/60 text-xl font-system max-w-xl">
-          From the moment you reach out to the last dance — here's how we make it happen.
+          From the moment you reach out to the last dance, here's how we make it happen.
         </p>
       </motion.div>
 


### PR DESCRIPTION
## Summary
Updates the "What Happens Next" (Process) section so it reflects the approved Femme service scope. Removes language implying budget management and aligns each step with the Amanda-approved copy.

## Changes
- **Step labels** renamed: Book → **Inquire**, Plan → **Get Organized**, Design → **Shape the Look**, Celebrate (unchanged).
- **Step 02** no longer mentions budgets. Now reflects vendor contracts, contact information, priorities, timelines, and moving pieces.
- **Step 03** reflects design direction (mood boards, palettes, floral notes, linens, stationery guidance, decor).
- **Step 04** reflects wedding-day logistics (timeline, vendors, setup, rehearsal).
- Removed visible em dashes from step copy and the section subtitle.

## Why
Amanda clarified service boundaries and Karan approved removing budget-management language. Copy matches the source review doc `docs/amanda-website-copy-draft.html` ("Light copy updates for 'What Happens Next'").

## Acceptance criteria
- [x] Process section no longer mentions budgets or budget management
- [x] Reflects vendor contracts, timelines, design direction, and wedding-day logistics
- [x] No visible em dashes in copy
- [x] Mobile horizontal-scroll behavior unchanged (only the `steps` data and subtitle text were edited)
- [x] `npm run lint` passes
- [x] `npm run build` passes

## Notes for reviewer
- Only `src/components/Process.tsx` changed — the section's structure, layout, and carousel logic are untouched.
- The source doc `docs/amanda-website-copy-draft.html` is a shared reference across content issues and is intentionally not committed in this PR.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)