### PR TITLE
content: remove coordinator-count language from FAQ and blog (#94)

### DIFF
--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -27,7 +27,7 @@ const faqs = [
   {
     question: "Can I customize my package?",
     answer:
-      "Absolutely. Every wedding is different, and we're not big on one-size-fits-all. Our à la carte add-ons (rehearsal dinner coordination, welcome party, extra coordinators, and more) let you tailor any package to exactly what you need. Tell us your situation and we'll build something that fits.",
+      "Absolutely. Every wedding is different, and we're not big on one-size-fits-all. Our à la carte add-ons (rehearsal dinner coordination, welcome party coordination, and more) let you tailor any package to exactly what you need. Tell us your situation and we'll build something that fits.",
   },
   {
     question: "How does pricing work?",

--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -82,9 +82,9 @@ At Femme Events, our day-of package includes:
 - Full vendor contact collection and timeline distribution
 - A day-of timeline we build from scratch (not a template)
 - Rehearsal coordination the evening before
-- Two coordinators on the actual day, for eight hours
+- All-day wedding management on the wedding day
 
-That last part matters. One coordinator cannot be in the bridal suite and at the venue entrance at the same time. You need two.
+That last part matters. No single person can be in the bridal suite and at the venue entrance at the same time, so we staff the day to keep every moving piece covered from setup through send-off.
 
 ## What it doesn't include
 


### PR DESCRIPTION
## Summary
Extends the #86 scope guardrail (never mention coordinator count anywhere on the site) to the spots PR #93 left out: the FAQ and the blog.

## Changes (code)
- **`src/components/FAQ.tsx`** — "Can I customize my package?" answer no longer lists "extra coordinators" as an add-on. Now reads "rehearsal dinner coordination, welcome party coordination, and more," consistent with the à la carte items in `Services.tsx`.
- **`src/data/posts.ts`** — `day-of-coordination-myths` post:
  - `- Two coordinators on the actual day, for eight hours` → `- All-day wedding management on the wedding day` (also drops the 8-hour cap per #86's "all-day wedding management" framing)
  - `One coordinator cannot be in the bridal suite and at the venue entrance at the same time. You need two.` → `No single person can be in the bridal suite and at the venue entrance at the same time, so we staff the day to keep every moving piece covered from setup through send-off.`

## ⚠️ Sanity action required (cannot be done in code)
The blog is CMS-managed (Sanity project `tc3rpyl9`, dataset `production`). `src/data/posts.ts` is **fallback** data — the live site renders from Sanity, where the same coordinator-count language is still published. I have read-only access, and the CMS is Amanda's to edit, so this must be applied in the Studio (femmeevents.sanity.studio).

**Post:** *Day-of Coordination: What It Actually Includes (And What It Doesn't)* (`day-of-coordination-myths`)

1. In the bulleted "our day-of package includes" list, change the last bullet:
   - From: `Two coordinators on the actual day, for eight hours`
   - To: `All-day wedding management on the wedding day`
2. In the paragraph right after that list, replace:
   - From: `That last part matters. One coordinator cannot be in the bridal suite and at the venue entrance at the same time. You need two.`
   - To: `That last part matters. No single person can be in the bridal suite and at the venue entrance at the same time, so we staff the day to keep every moving piece covered from setup through send-off.`

(For reference, these are Portable Text blocks `b4` and `b5` in the post body.)

> Note: the generic phrase "Coordinators are logistics" in the *Six Months Out* post is **not** a count and was intentionally left as-is, in both code and Sanity.

## Acceptance criteria
- [x] No coordinator-count language remains in `FAQ.tsx`
- [x] Static `posts.ts` no longer states a specific number of coordinators
- [ ] **Sanity live content** updated (see action above — needs Amanda/Studio)
- [x] Wording consistent with approved Services copy ("all-day wedding management")
- [x] `npm run lint` passes
- [x] `npm run build` passes

## Verification
- `grep -rniE "two coordinator|second coordinator|extra coordinator|you need two|for eight hours" src/` → no matches
- Scanned all 3 live Sanity posts; only `day-of-coordination-myths` carries count language.

Related: #86, PR #93
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)