### PR TITLE
content: update FAQ package names to match Services (#96)

### DIFF
--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -22,7 +22,7 @@ const faqs = [
   {
     question: "What's the difference between your packages?",
     answer:
-      "Just Show Up (Day-of) is for couples who've planned everything and just need someone to execute flawlessly on the day. Getting It Together (Partial) adds planning sessions, vendor support, and design direction. The Full Femme is end-to-end — design, planning, logistics, and everything in between. You can also mix in à la carte add-ons to any package.",
+      "In Your Corner (Wedding Coordination) is for couples who've planned everything and just need someone to run the day flawlessly. Getting It Together (Partial Planning + Coordination) adds planning sessions, vendor support, and decor coordination. The Full Femme (Full Coordination + Design Guidance) is the end-to-end option: full design direction, planning, logistics, and everything in between. You can also mix in à la carte add-ons to any package.",
   },
   {
     question: "Can I customize my package?",


### PR DESCRIPTION
## Summary
Aligns the FAQ with the renamed/rescoped Services packages from #86/#93. Only the "What's the difference between your packages?" answer changed.

## Changes (`src/components/FAQ.tsx`)
- Package names/subtitles now match `Services.tsx`:
  - Just Show Up (Day-of) → **In Your Corner** (Wedding Coordination)
  - Getting It Together (Partial) → **Getting It Together** (Partial Planning + Coordination)
  - The Full Femme → **The Full Femme** (Full Coordination + Design Guidance)
- Moved design direction to **The Full Femme** only; the partial tier now reads "decor coordination," matching the approved #86 scope (design guidance lives in The Full Femme).
- Removed the em dash from the answer copy.

## Scope note
The "extra coordinators" / coordinator-count concern in this issue was already resolved by **#94 (PR #100, merged)**, which is now on `main`. This PR therefore contains only the package-name update — no overlap remains.

## Acceptance criteria
- [x] FAQ uses the current package names/subtitles from Services
- [x] FAQ does not mention coordinator counts or "extra coordinators" (already clean via #94)
- [x] FAQ remains clear about customization and inquiry-only pricing (those answers unchanged)
- [x] `npm run lint` passes
- [x] `npm run build` passes

## Verification
- `grep -nE "Just Show Up|\(Partial\)|\(Day-of\)" src/components/FAQ.tsx` → no matches
- `grep -niE "extra coordinator|two coordinator" src/components/FAQ.tsx` → no matches

Related: #86, #93, #94
Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)