### PR TITLE
Fix font artifacts for special symbols

### DIFF
--- a/components/ui/framer-carousel.tsx
+++ b/components/ui/framer-carousel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { motion, useMotionValue, animate } from 'motion/react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import SafeText from '@/src/components/SafeText';
 
 export interface CarouselItem {
   id: number;
@@ -69,7 +70,9 @@ export function FramerCarousel({ items }: FramerCarouselProps) {
 
               {/* Caption */}
               <div className="absolute bottom-0 left-0 right-0 p-8">
-                <p className="text-white text-3xl font-bold font-balgin">{item.couple}</p>
+                <p className="text-white text-3xl font-bold font-balgin">
+                  <SafeText text={item.couple} />
+                </p>
                 <p className="text-white/70 text-sm font-system mt-1">{item.location} · {item.detail}</p>
               </div>
             </div>

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,4 +1,5 @@
 import { motion } from "motion/react";
+import SafeText from "./SafeText";
 
 const aboutParagraphs = [
   `As women, we're told a wedding is supposed to be the "most important day of our lives." And listen, we know life has plenty of other milestones worth screaming about: the promotion, the degree, the first home, the babies if you want them, the version of yourself you worked hard to become.`,
@@ -34,7 +35,7 @@ export default function About() {
         className="flex flex-col gap-8"
       >
         <h2 className="text-5xl md:text-8xl text-femme-dark leading-tight italic">
-          Why We Obsess Over&nbsp;"I Do"
+          <SafeText text='Why We Obsess Over "I Do"' />
         </h2>
         <div className="flex flex-col gap-5 text-femme-dark/80 text-lg md:text-xl leading-relaxed max-w-xl">
           {aboutParagraphs.map((paragraph, index) => (

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { Plus, Minus } from "lucide-react";
 import { trackEvent } from "../lib/analytics";
+import SafeText from "./SafeText";
 
 const faqs = [
   {
@@ -91,7 +92,7 @@ export default function FAQ() {
           className="md:sticky md:top-32"
         >
           <h2 className="text-5xl md:text-8xl text-femme-dark italic leading-tight mb-4">
-            Questions We Actually Get Asked
+            <SafeText text="Questions We Actually Get Asked" />
           </h2>
           <div className="h-1 w-32 bg-femme-orange mb-6" />
           <p className="text-femme-dark/60 text-lg font-system leading-relaxed">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,6 @@
 import { motion } from "motion/react";
 import { trackEvent } from "../lib/analytics";
+import SafeText from "./SafeText";
 
 export default function Hero() {
   return (
@@ -34,7 +35,7 @@ export default function Hero() {
           className="text-white/90 text-lg md:text-xl uppercase tracking-[0.3em] drop-shadow-md"
           style={{ fontFamily: "Balgin, serif" }}
         >
-          Atlanta Wedding Partial Planning &amp; Design
+          <SafeText text="Atlanta Wedding Partial Planning & Design" />
         </motion.p>
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -68,8 +69,8 @@ export default function Hero() {
         </div>
         <div className="flex flex-col gap-1.5 md:gap-2 text-right md:text-center">
           <span className="text-[10px] md:text-xs uppercase tracking-widest opacity-75">Email</span>
-          <span className="text-sm md:text-xl font-medium drop-shadow-md break-all md:break-normal">
-            Amanda<span style={{ fontFamily: 'system-ui, sans-serif' }}>@</span>FemmeEvents.com
+          <span className="text-sm md:text-xl font-medium drop-shadow-md break-all md:break-normal font-system">
+            Amanda@FemmeEvents.com
           </span>
         </div>
         <div className="flex flex-col gap-1.5 md:gap-2 md:text-center">
@@ -79,14 +80,14 @@ export default function Hero() {
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => trackEvent("instagram_click", { location: "hero" })}
-            className="text-base md:text-xl font-medium drop-shadow-md hover:opacity-70 transition-opacity duration-200"
+            className="text-base md:text-xl font-medium drop-shadow-md hover:opacity-70 transition-opacity duration-200 font-system"
           >
-            <span style={{ fontFamily: 'system-ui, sans-serif' }}>@_</span>femmeevents
+            @_femmeevents
           </a>
         </div>
         <div className="flex flex-col gap-1.5 md:gap-2 text-right">
           <span className="text-[10px] md:text-xs uppercase tracking-widest opacity-75">Phone</span>
-          <span className="text-base md:text-xl font-medium drop-shadow-md" style={{ fontFamily: 'system-ui, sans-serif' }}>(678) 644-5257</span>
+          <span className="text-base md:text-xl font-medium drop-shadow-md font-system">(678) 644-5257</span>
         </div>
       </motion.div>
     </section>

--- a/src/components/Inquiry.tsx
+++ b/src/components/Inquiry.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
 import { trackEvent } from "../lib/analytics";
+import SafeText from "./SafeText";
 
 const labelClass = "text-xs uppercase tracking-widest font-bold opacity-60 font-system";
 const inputClass =
@@ -66,10 +67,10 @@ export default function Inquiry() {
   /* ──────────── Success state ──────────── */
   if (state === "success") {
     return (
-      <section id="inquiry" className="scroll-mt-24 md:scroll-mt-28 py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16 items-center">
+      <section id="inquiry" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16 items-center">
         <div className="flex flex-col gap-6">
           <h2 className="text-6xl md:text-8xl text-femme-dark leading-[0.95] italic">
-            Ready to Chat Dates &amp; Dreams?
+            <SafeText text="Ready to Chat Dates & Dreams?" />
           </h2>
           <p className="text-femme-dark/70 text-xl font-system">
             Drop us a line and let&apos;s see if your calendar and our magic align.
@@ -83,7 +84,9 @@ export default function Inquiry() {
           className="flex flex-col items-center justify-center text-center gap-6 py-16 px-8 bg-femme-cream/80 rounded-2xl border border-femme-pink/30"
         >
           <CheckCircle2 size={56} className="text-femme-plum" strokeWidth={1.5} />
-          <h3 className="text-4xl text-femme-dark font-display">You&apos;re In!</h3>
+          <h3 className="text-4xl text-femme-dark font-display">
+            <SafeText text="You're In!" />
+          </h3>
           <p className="text-femme-dark/60 text-lg font-system max-w-md">
             We&apos;ll review your inquiry and get back to you within 24 hours. 
             Check your inbox (and spam) for our reply.
@@ -95,7 +98,7 @@ export default function Inquiry() {
 
   /* ──────────── Normal form ──────────── */
   return (
-    <section id="inquiry" className="scroll-mt-24 md:scroll-mt-28 py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16">
+    <section id="inquiry" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16">
       {/* Audience / differentiator — confidence block before the form (Issue #87) */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
@@ -105,8 +108,7 @@ export default function Inquiry() {
         className="md:col-span-2 max-w-3xl mx-auto text-center"
       >
         <p className="text-femme-dark text-3xl md:text-4xl italic font-display leading-tight mb-8">
-          You belong here if you want the wedding to feel like you, not like a
-          checklist someone handed you.
+          <SafeText text="You belong here if you want the wedding to feel like you, not like a checklist someone handed you." />
         </p>
         <p className="text-femme-dark/70 text-base md:text-lg font-system leading-relaxed mb-8">
           Bring us the disco balls, the bows, the moody florals, the dramatic
@@ -115,13 +117,13 @@ export default function Inquiry() {
           mood board, the silly inside joke, the “is this too much?” idea.
         </p>
         <p className="text-femme-plum text-2xl md:text-3xl italic font-display">
-          It is not too much. It is the point.
+          <SafeText text="It is not too much. It is the point." />
         </p>
       </motion.div>
 
       <div className="flex flex-col gap-6">
         <h2 className="text-6xl md:text-8xl text-femme-dark leading-[0.95] italic">
-          Ready to Chat Dates &amp; Dreams?
+          <SafeText text="Ready to Chat Dates & Dreams?" />
         </h2>
         <p className="text-femme-dark/70 text-xl font-system">
           Drop us a line and let&apos;s see if your calendar and our magic align.

--- a/src/components/Process.tsx
+++ b/src/components/Process.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import CarouselDots from "./CarouselDots";
 import { useCarouselIndex } from "../lib/useCarouselIndex";
 import { trackEvent } from "../lib/analytics";
+import SafeText from "./SafeText";
 
 const steps = [
   {
@@ -93,7 +94,7 @@ export default function Process() {
                 className="text-5xl text-femme-dark"
                 style={{ fontFamily: "Frunchy Sage, serif", fontWeight: "bold" }}
               >
-                {step.label}
+                <SafeText text={step.label} />
               </h3>
 
               {/* Description */}

--- a/src/components/SafeText.tsx
+++ b/src/components/SafeText.tsx
@@ -1,0 +1,60 @@
+import { Fragment, cloneElement, isValidElement, type ReactNode } from "react";
+
+const SYMBOL_SPLIT_PATTERN = /([&+@_/()•©·"'‘’“”–—-])/g;
+const SYMBOL_ONLY_PATTERN = /^[&+@_/()•©·"'‘’“”–—-]$/;
+
+interface SafeTextProps {
+  text: string;
+  symbolClassName?: string;
+}
+
+export default function SafeText({
+  text,
+  symbolClassName = "font-symbol",
+}: SafeTextProps) {
+  const parts = text.split(SYMBOL_SPLIT_PATTERN).filter(Boolean);
+
+  return (
+    <>
+      {parts.map((part, index): ReactNode =>
+        SYMBOL_ONLY_PATTERN.test(part) ? (
+          <span key={`${part}-${index}`} className={symbolClassName}>
+            {part}
+          </span>
+        ) : (
+          part
+        ),
+      )}
+    </>
+  );
+}
+
+function renderSafeNode(node: ReactNode, symbolClassName: string): ReactNode {
+  if (typeof node === "string") {
+    return <SafeText text={node} symbolClassName={symbolClassName} />;
+  }
+
+  if (Array.isArray(node)) {
+    return node.map((child, index) => (
+      <Fragment key={index}>{renderSafeNode(child, symbolClassName)}</Fragment>
+    ));
+  }
+
+  if (isValidElement<{ children?: ReactNode }>(node) && node.props.children) {
+    return cloneElement(node, {
+      children: renderSafeNode(node.props.children, symbolClassName),
+    });
+  }
+
+  return node;
+}
+
+export function SafeTextContent({
+  children,
+  symbolClassName = "font-symbol",
+}: {
+  children: ReactNode;
+  symbolClassName?: string;
+}) {
+  return <>{renderSafeNode(children, symbolClassName)}</>;
+}

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "motion/react";
 import CarouselDots from "./CarouselDots";
 import { useCarouselIndex } from "../lib/useCarouselIndex";
 import { trackEvent } from "../lib/analytics";
+import SafeText from "./SafeText";
 
 const services = [
   {
@@ -158,7 +159,7 @@ function ServiceCard({
             className="text-white text-5xl md:text-6xl leading-tight mb-2"
             style={{ fontFamily: "Frunchy Sage, serif", fontWeight: "bold" }}
           >
-            {service.title}
+            <SafeText text={service.title} />
           </h3>
           <p className="text-femme-pink text-sm uppercase tracking-[0.25em] font-bold font-system">
             {service.subtitle}
@@ -194,7 +195,7 @@ export default function Services() {
       {/* Header */}
       <div className="mb-16">
         <h2 className="text-5xl md:text-8xl text-femme-dark leading-tight italic mb-6">
-          For the look, the feeling, and every moving piece in between.
+          <SafeText text="For the look, the feeling, and every moving piece in between." />
         </h2>
         <div className="h-1 w-32 bg-femme-orange mb-8" />
         <div className="max-w-3xl">

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -8,22 +8,7 @@ import {
 import { testimonials as fallbackTestimonials } from "../data/testimonials";
 import { useCarouselIndex } from "../lib/useCarouselIndex";
 import CarouselDots from "./CarouselDots";
-
-function Name({ children }: { children: string }) {
-  const parts = children.split("&");
-  return (
-    <>
-      {parts.map((part, i) => (
-        <span key={i}>
-          {part}
-          {i < parts.length - 1 && (
-            <span className="font-system">&amp;</span>
-          )}
-        </span>
-      ))}
-    </>
-  );
-}
+import SafeText from "./SafeText";
 
 export default function Testimonials() {
   const [testimonials, setTestimonials] = useState<Testimonial[]>(
@@ -112,7 +97,7 @@ export default function Testimonials() {
             {/* Attribution */}
             <div className="flex flex-col gap-2 items-center text-center">
               <span className="text-femme-plum text-3xl font-bold font-balgin">
-                <Name>{t.name}</Name>
+                <SafeText text={t.name} />
               </span>
               <span className="text-femme-dark/50 text-sm font-system">
                 {t.detail}

--- a/src/components/Vendors.tsx
+++ b/src/components/Vendors.tsx
@@ -9,6 +9,7 @@ import {
 import { vendorCategories as fallbackCategories } from "../data/vendors";
 import VendorOverlayCard from "./ui/VendorOverlayCard";
 import { trackEvent } from "../lib/analytics";
+import SafeText from "./SafeText";
 
 interface SelectedVendor {
   vendor: Vendor;
@@ -47,7 +48,7 @@ function VendorCard({
     >
       <div className="flex flex-col gap-0.5 min-w-0">
         <span className="text-femme-dark text-base font-balgin truncate">
-          {vendor.name}
+          <SafeText text={vendor.name} />
         </span>
         <span className="text-femme-dark/50 text-xs font-system truncate">
           {vendor.specialty}
@@ -114,7 +115,7 @@ export default function Vendors() {
             >
               <h3 className="text-2xl text-femme-plum font-balgin mb-4 flex items-center gap-3">
                 <span className="w-2 h-2 rounded-full bg-femme-orange shrink-0" />
-                {cat.label}
+                <SafeText text={cat.label} />
               </h3>
               <ul className="flex flex-col gap-3 min-w-0 max-w-full">
                 {cat.vendors.map((vendor, i) => (

--- a/src/components/ui/VendorOverlayCard.tsx
+++ b/src/components/ui/VendorOverlayCard.tsx
@@ -3,6 +3,7 @@ import { motion } from "motion/react";
 import { ExternalLink, Instagram, X } from "lucide-react";
 import { instagramUrl } from "../../lib/vendors";
 import { trackEvent } from "../../lib/analytics";
+import SafeText from "../SafeText";
 
 interface VendorOverlayCardProps {
   name: string;
@@ -125,7 +126,7 @@ export default function VendorOverlayCard({
             id="vendor-overlay-name"
             className="text-femme-dark text-3xl font-balgin mb-2"
           >
-            {name}
+            <SafeText text={name} />
           </h3>
           <p className="text-femme-dark/60 text-sm font-system leading-relaxed">
             {specialty}

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,13 @@
 @layer base {
   html {
     scroll-behavior: smooth;
+    scroll-padding-top: 6rem;
+  }
+
+  @media (min-width: 768px) {
+    html {
+      scroll-padding-top: 7rem;
+    }
   }
 
   body {
@@ -89,6 +96,15 @@
    to avoid The Seasons' stylized glyphs on +, (, ), /, –, etc. */
 .font-system {
   font-family: system-ui, -apple-system, sans-serif;
+}
+
+/* Keep decorative brand fonts from substituting ornamental glyphs for common
+   punctuation in display headings and CMS-driven names. */
+.font-symbol {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-style: normal;
+  font-weight: inherit;
+  letter-spacing: 0;
 }
 
 /* ─── Grain Texture ────────────────────────────── */

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,5 +1,6 @@
 import { motion } from "motion/react";
 import { Link } from "react-router-dom";
+import SafeText from "../components/SafeText";
 
 const storyParagraphs = [
   `Femme Events started with a simple frustration: weddings can feel way too obsessed with rules.`,
@@ -29,7 +30,7 @@ export default function AboutPage() {
             Our Story
           </p>
           <h1 className="mb-6 text-5xl italic text-femme-dark md:text-7xl">
-            For celebrations with feeling, personality, and a plan.
+            <SafeText text="For celebrations with feeling, personality, and a plan." />
           </h1>
           <div className="h-1 w-32 bg-femme-orange" />
         </motion.div>
@@ -45,7 +46,7 @@ export default function AboutPage() {
             <p key={index}>{paragraph}</p>
           ))}
           <p className="mt-2 text-3xl italic leading-snug text-femme-plum md:text-4xl">
-            {closingLine}
+            <SafeText text={closingLine} />
           </p>
         </motion.div>
 
@@ -58,7 +59,7 @@ export default function AboutPage() {
         >
           <div>
             <h2 className="text-3xl text-femme-dark font-balgin">
-              Ready when you are
+              <SafeText text="Ready when you are" />
             </h2>
             <p className="mt-2 text-femme-dark/60 font-system">
               Tell us about your wedding and we'll take it from there.

--- a/src/pages/BlogIndex.tsx
+++ b/src/pages/BlogIndex.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "motion/react";
 import { ArrowRight } from "lucide-react";
 import { getInitialPosts, getPosts, formatPostDate, type Post } from "../lib/posts";
+import SafeText from "../components/SafeText";
 import {
   buildSrcSet,
   parseSanityDimensions,
@@ -46,7 +47,7 @@ function FeaturedPost({ post }: { post: Post }) {
         </div>
 
         <h2 className="text-[2.475rem] md:text-[3.3rem] text-femme-dark leading-tight italic">
-          {post.title}
+          <SafeText text={post.title} />
         </h2>
 
         <p className="text-femme-dark/65 text-[1.2375rem] leading-relaxed font-system">
@@ -103,7 +104,7 @@ function PostCard({ post, index }: { post: Post; index: number }) {
 
       {/* Title */}
       <h3 className="text-[1.65rem] text-femme-dark leading-snug group-hover:text-femme-plum transition-colors duration-200">
-        {post.title}
+        <SafeText text={post.title} />
       </h3>
 
       {/* Excerpt */}

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -9,6 +9,7 @@ import {
   parseSanityDimensions,
   sanityImageUrl,
 } from "../lib/imageUrl";
+import SafeText, { SafeTextContent } from "../components/SafeText";
 
 const HERO_WIDTHS = [600, 900, 1200, 1600, 2000];
 
@@ -17,7 +18,9 @@ const HERO_WIDTHS = [600, 900, 1200, 1600, 2000];
 const portableTextComponents: PortableTextComponents = {
   block: {
     h2: ({ children }) => (
-      <h2 className="text-3xl text-femme-dark mt-10 mb-4 italic">{children}</h2>
+      <h2 className="text-3xl text-femme-dark mt-10 mb-4 italic">
+        <SafeTextContent>{children}</SafeTextContent>
+      </h2>
     ),
     normal: ({ children }) => (
       <p className="text-femme-dark/80 text-lg leading-relaxed font-system">
@@ -57,7 +60,7 @@ function renderMarkdownBody(body: string) {
     if (block.startsWith("## ")) {
       return (
         <h2 key={i} className="text-3xl text-femme-dark mt-10 mb-4 italic">
-          {block.replace("## ", "")}
+          <SafeText text={block.replace("## ", "")} />
         </h2>
       );
     }
@@ -166,7 +169,7 @@ export default function BlogPost() {
             <span className="text-xs text-femme-dark/50">{formatPostDate(post.date)}</span>
           </div>
           <h1 className="text-5xl md:text-6xl text-femme-dark leading-tight italic mb-4">
-            {post.title}
+            <SafeText text={post.title} />
           </h1>
           <p className="text-femme-dark/60 text-xl leading-relaxed font-system">
             {post.excerpt}

--- a/src/pages/WhatHappensNext.tsx
+++ b/src/pages/WhatHappensNext.tsx
@@ -1,5 +1,6 @@
 import { motion } from "motion/react";
 import { Link } from "react-router-dom";
+import SafeText from "../components/SafeText";
 
 const timeline = [
   {
@@ -90,7 +91,7 @@ export default function WhatHappensNextPage() {
             After you book
           </p>
           <h1 className="mb-6 text-6xl italic text-femme-dark md:text-8xl lg:text-9xl">
-            The Planning Flow
+            <SafeText text="The Planning Flow" />
           </h1>
           <div className="h-1 w-32 bg-femme-orange" />
           <p className="mt-6 max-w-2xl text-xl leading-relaxed text-femme-dark/65 font-system">
@@ -115,7 +116,7 @@ export default function WhatHappensNextPage() {
                 <span className="h-px flex-1 bg-femme-plum/15" aria-hidden="true" />
               </div>
               <h2 className="mb-3 text-3xl text-femme-dark font-balgin">
-                {step.title}
+                <SafeText text={step.title} />
               </h2>
               <p className="text-base leading-relaxed text-femme-dark/65 font-system">
                 {step.description}
@@ -133,7 +134,7 @@ export default function WhatHappensNextPage() {
         >
           <div>
             <h2 className="text-3xl text-femme-dark font-balgin">
-              Want us in your corner?
+              <SafeText text="Want us in your corner?" />
             </h2>
             <p className="mt-2 text-femme-dark/60 font-system">
               Start with the inquiry form and we’ll take it from there.

--- a/studio/schemas/testimonial.ts
+++ b/studio/schemas/testimonial.ts
@@ -9,7 +9,7 @@ export const testimonial = defineType({
       name: "name",
       title: "Couple / Client Name",
       type: "string",
-      description: 'e.g. "Priscila & Tri" — the ampersand renders in the system font.',
+      description: 'e.g. "Priscila & Tri" — special symbols render with the site fallback font.',
       validation: (Rule) => Rule.required(),
     }),
     defineField({


### PR DESCRIPTION
## Summary
- Adds a reusable `SafeText` renderer that wraps common special symbols in a reliable system-font fallback while preserving Femme brand typography for surrounding text.
- Applies the fallback across display/subheading text paths: hero copy, inquiry headings, testimonials, vendor labels/names, service/process titles, blog titles/headings, and standalone pages.
- Updates the Sanity testimonial schema helper text so future content authors know special symbols are handled by the site fallback.

Closes #91

## Visual QA
- Desktop home: checked hero subtitle ampersand, contact `@`, `_`, and phone punctuation; testimonial names; vendor names/categories; inquiry heading ampersand.
- Mobile home (390x844): checked hero subtitle ampersand, contact handle/phone, and inquiry copy wrapping.
- Journal/blog routes: checked blog index and a sample blog post with punctuation-heavy titles and body text.
- DOM audit confirmed affected text is present as intended, including `Atlanta Wedding Partial Planning & Design`, `Ready to Chat Dates & Dreams?`, `Priscila & Tri`, `Kaitlyn & James`, `Florals & Design`, `Music & Entertainment`, `Photo & Video`, `Moss & Clay Floral Design`, `@_femmeevents`, and `(678) 644-5257`.

Local QA screenshots are saved at `/tmp/femme-events-issue-91/`.

## Tests
- `npm run build`
- `git diff --check`
