### PR TITLE
[codex] Add global anchor scroll offset

### DIFF
--- a/src/components/Inquiry.tsx
+++ b/src/components/Inquiry.tsx
@@ -66,7 +66,7 @@ export default function Inquiry() {
   /* ──────────── Success state ──────────── */
   if (state === "success") {
     return (
-      <section id="inquiry" className="scroll-mt-24 md:scroll-mt-28 py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16 items-center">
+      <section id="inquiry" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16 items-center">
         <div className="flex flex-col gap-6">
           <h2 className="text-6xl md:text-8xl text-femme-dark leading-[0.95] italic">
             Ready to Chat Dates &amp; Dreams?
@@ -95,7 +95,7 @@ export default function Inquiry() {
 
   /* ──────────── Normal form ──────────── */
   return (
-    <section id="inquiry" className="scroll-mt-24 md:scroll-mt-28 py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16">
+    <section id="inquiry" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16">
       {/* Audience / differentiator — confidence block before the form (Issue #87) */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,13 @@
 @layer base {
   html {
     scroll-behavior: smooth;
+    scroll-padding-top: 6rem;
+  }
+
+  @media (min-width: 768px) {
+    html {
+      scroll-padding-top: 7rem;
+    }
   }
 
   body {


### PR DESCRIPTION
## Summary
- Add global `scroll-padding-top` to `html` so hash anchors clear the fixed floating navbar.
- Remove the scoped `scroll-mt-24 md:scroll-mt-28` from both `#inquiry` render states to avoid double-offset now that the root fix covers all anchors.

## Why
The fixed navbar can cover anchored sections when navigating to `#services`, `#about`, or `#inquiry`. A document-level scroll offset fixes the root behavior for all hash navigation instead of handling individual sections one by one.

Closes #98

## Validation
- `npm run lint`
- `npm run build`
- Previously verified anchor landing positions in browser at desktop `1280x720` and mobile `390x844`; all target section tops clear the navbar.
