### PR TITLE
feat: prefill inquiry form from selected service package (#95)

### DIFF
--- a/src/components/Inquiry.tsx
+++ b/src/components/Inquiry.tsx
@@ -25,11 +25,13 @@ export default function Inquiry() {
     () => labelForSlug(new URLSearchParams(location.search).get("service")) || NOT_SURE_LABEL,
   );
 
-  // Keep the dropdown in sync when the URL param changes — e.g. a visitor
-  // already at the form clicks a different package's "Book Now".
+  // Keep the dropdown mirroring the URL's ?service= param across every SPA
+  // navigation: clicking a different package's "Book Now", and also Back/Forward
+  // or an invalid/removed slug — both reset to the neutral fallback so the form
+  // never shows a stale package the URL no longer reflects.
   useEffect(() => {
     const label = labelForSlug(new URLSearchParams(location.search).get("service"));
-    if (label) setSelectedService(label);
+    setSelectedService(label || NOT_SURE_LABEL);
   }, [location.search]);
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {

--- a/src/components/Inquiry.tsx
+++ b/src/components/Inquiry.tsx
@@ -1,7 +1,9 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
+import { useLocation } from "react-router-dom";
 import { motion, AnimatePresence } from "motion/react";
 import { CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
 import { trackEvent } from "../lib/analytics";
+import { SERVICE_OPTIONS, NOT_SURE_LABEL, labelForSlug } from "../data/serviceOptions";
 
 const labelClass = "text-xs uppercase tracking-widest font-bold opacity-60 font-system";
 const inputClass =
@@ -12,9 +14,22 @@ const FORM_ACTION = import.meta.env.VITE_FORMSPREE_ENDPOINT || "";
 type SubmitState = "idle" | "loading" | "success" | "error";
 
 export default function Inquiry() {
+  const location = useLocation();
   const [hasVenue, setHasVenue] = useState(false);
   const [state, setState] = useState<SubmitState>("idle");
   const [errorMsg, setErrorMsg] = useState("");
+  // Prefilled from `?service=<slug>` when a visitor clicks a Services card;
+  // defaults to "Not sure yet" for anyone who reaches the form directly.
+  const [selectedService, setSelectedService] = useState(
+    () => labelForSlug(new URLSearchParams(location.search).get("service")) || NOT_SURE_LABEL,
+  );
+
+  // Keep the dropdown in sync when the URL param changes — e.g. a visitor
+  // already at the form clicks a different package's "Book Now".
+  useEffect(() => {
+    const label = labelForSlug(new URLSearchParams(location.search).get("service"));
+    if (label) setSelectedService(label);
+  }, [location.search]);
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -48,8 +63,9 @@ export default function Inquiry() {
       if (res.ok) {
         setState("success");
         form.reset();
-        // Conversion signal only — no form-field contents are ever sent.
-        trackEvent("inquiry_submit", { location: "inquiry_form" });
+        // Conversion signal only — selected package is a non-personal category,
+        // never the visitor's name, email, or message.
+        trackEvent("inquiry_submit", { location: "inquiry_form", service: selectedService });
       } else {
         throw new Error(`Server responded with ${res.status}`);
       }
@@ -159,6 +175,27 @@ export default function Inquiry() {
         <div className="flex flex-col gap-2">
           <label htmlFor="email" className={labelClass}>Email</label>
           <input id="email" name="email" type="email" required className={inputClass} disabled={submitting} />
+        </div>
+
+        {/* Interested Service — prefilled from the clicked Services card (#95),
+            editable here, and sent to Formspree as `interestedService`. */}
+        <div className="flex flex-col gap-2">
+          <label htmlFor="interestedService" className={labelClass}>Interested Service</label>
+          <select
+            id="interestedService"
+            name="interestedService"
+            value={selectedService}
+            onChange={(e) => setSelectedService(e.target.value)}
+            className={inputClass}
+            disabled={submitting}
+          >
+            {SERVICE_OPTIONS.map((option) => (
+              <option key={option.slug} value={option.label}>
+                {option.label}
+              </option>
+            ))}
+            <option value={NOT_SURE_LABEL}>{NOT_SURE_LABEL}</option>
+          </select>
         </div>
 
         {/* Event Date + Guest Count */}

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "motion/react";
 import CarouselDots from "./CarouselDots";
 import { useCarouselIndex } from "../lib/useCarouselIndex";
 import { trackEvent } from "../lib/analytics";
+import { inquiryHrefForLabel } from "../data/serviceOptions";
 
 const services = [
   {
@@ -94,6 +96,11 @@ function ServiceCard({
   index: number;
 }) {
   const [hovered, setHovered] = useState(false);
+  const navigate = useNavigate();
+
+  // Carries the clicked package to the inquiry form via the URL, e.g.
+  // `/?service=the-full-femme#inquiry`, so the form can prefill it.
+  const inquiryHref = inquiryHrefForLabel(service.title);
 
   return (
     <motion.div
@@ -165,10 +172,17 @@ function ServiceCard({
           </p>
         </div>
 
-        {/* Book Now button — links to inquiry section */}
+        {/* Book Now button — carries the selected package to the inquiry form.
+            The real href keeps right-click/open-in-new-tab and no-JS fallback
+            working; the click handler does a client-side navigation so visitors
+            don't pay for a full reload, then ScrollToHash scrolls to #inquiry. */}
         <motion.a
-          href="#inquiry"
-          onClick={() => trackEvent("cta_inquiry_click", { location: "service_card", service: service.title })}
+          href={inquiryHref}
+          onClick={(e) => {
+            e.preventDefault();
+            trackEvent("cta_inquiry_click", { location: "service_card", service: service.title });
+            navigate(inquiryHref);
+          }}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
           aria-label={`Book ${service.title} — jump to inquiry form`}

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -174,15 +174,23 @@ function ServiceCard({
         </div>
 
         {/* Book Now button — carries the selected package to the inquiry form.
-            The real href keeps right-click/open-in-new-tab and no-JS fallback
-            working; the click handler does a client-side navigation so visitors
-            don't pay for a full reload, then ScrollToHash scrolls to #inquiry. */}
+            The real href keeps no-JS fallback and modified-click (open in new
+            tab/window) working; a plain left-click does a client-side navigation
+            instead so visitors don't pay for a full reload. */}
         <motion.a
           href={inquiryHref}
           onClick={(e) => {
+            // Let the browser handle modified clicks via the real href so
+            // Cmd/Ctrl/Shift-click still opens the form in a new tab/window.
+            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
             e.preventDefault();
             trackEvent("cta_inquiry_click", { location: "service_card", service: service.title });
             navigate(inquiryHref);
+            // Scroll explicitly: switching packages while already at #inquiry is
+            // a search-only URL change, so ScrollToHash (keyed on pathname/hash)
+            // won't re-fire. The section always exists on the home page, and
+            // the global scroll-padding-top keeps it clear of the navbar.
+            document.getElementById("inquiry")?.scrollIntoView();
           }}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}

--- a/src/data/serviceOptions.ts
+++ b/src/data/serviceOptions.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical service packages — the single source of truth for the slugs that
+ * link a clicked Services card to the inquiry form's "Interested Service" field
+ * (issue #95). Both Services.tsx (to build the CTA link) and Inquiry.tsx (to
+ * read the URL param and render the dropdown) import from here, so slugs and
+ * labels never drift apart.
+ *
+ * Labels MUST match the card titles in src/components/Services.tsx exactly,
+ * since Services maps a card to its slug by label.
+ */
+
+export type ServiceOption = { slug: string; label: string };
+
+export const SERVICE_OPTIONS: ServiceOption[] = [
+  { slug: "in-your-corner", label: "In Your Corner" },
+  { slug: "getting-it-together", label: "Getting It Together" },
+  { slug: "the-full-femme", label: "The Full Femme" },
+];
+
+// Neutral fallback for visitors who reach the form without picking a package.
+export const NOT_SURE_LABEL = "Not sure yet";
+
+/** Maps a card label to its CTA link, e.g. `/?service=the-full-femme#inquiry`. */
+export function inquiryHrefForLabel(label: string): string {
+  const slug = SERVICE_OPTIONS.find((o) => o.label === label)?.slug;
+  return slug ? `/?service=${slug}#inquiry` : "#inquiry";
+}
+
+/** Resolves a URL `?service=<slug>` value back to its display label, or "". */
+export function labelForSlug(slug: string | null): string {
+  if (!slug) return "";
+  return SERVICE_OPTIONS.find((o) => o.slug === slug)?.label ?? "";
+}


### PR DESCRIPTION
## Summary

When a visitor clicks **Book Now** on a Services card, the inquiry form now remembers which package they wanted instead of making them re-type it — and the choice flows through to Amanda's Formspree email.

Closes #95 (follow-up to #43).

## What changed

- **`src/data/serviceOptions.ts`** (new) — single source of truth for service slugs/labels, imported by both Services and Inquiry so the two can't drift.
- **`src/components/Services.tsx`** — each card's CTA now points to `/?service=<slug>#inquiry` and navigates client-side via `useNavigate` (no full reload). The real `href` is preserved so right-click / open-in-new-tab / no-JS still work, then `ScrollToHash` handles the scroll.
- **`src/components/Inquiry.tsx`** — reads `?service=<slug>` into a **visible, editable** "Interested Service" `<select>` (defaults to *Not sure yet*), stays in sync if a different package is clicked, and includes `interestedService` in the Formspree payload.

## Approach notes

- Chose a **search param** (`/?service=<slug>#inquiry`) over a hash param so the existing `ScrollToHash` in `App.tsx` keeps working unchanged — `App.tsx` was **not** touched.
- Slugs live only in `serviceOptions.ts`; Services maps a card → slug by its label, so there's no duplicated slug list.
- Privacy: analytics still fire. `cta_inquiry_click` is unchanged; `inquiry_submit` now carries the **package name only** (a non-personal category) — never name/email/message.

## Acceptance criteria

- [x] Clicking Book Now on each card navigates to the inquiry section
- [x] Form prefilled with the matching package
- [x] Selection is visible & editable before submit
- [x] Direct visits to `#inquiry` default to *Not sure yet*
- [x] Formspree payload includes `interestedService`
- [x] Existing analytics still fire with service context; no personal fields sent to analytics
- [x] `npm run lint` passes (tsc --noEmit)
- [x] `npm run build` passes
- [x] Browser QA — desktop (1280×900) and mobile (390×844)

## How it was verified

Headless-Chromium QA on desktop + mobile (22/22 checks): all three deep-link slugs prefill the right package; unknown slug falls back to *Not sure yet*; clicking a card does client-side nav + smooth-scrolls to `#inquiry` + prefills; dropdown is editable. Submitting against a mock endpoint produced:

```json
{"firstName":"Test","lastName":"User","email":"test@example.com","interestedService":"The Full Femme","eventDate":"","guestCount":"","message":"..."}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)