### PR TITLE
Polish special-symbol typography

### DIFF
--- a/src/components/SafeText.tsx
+++ b/src/components/SafeText.tsx
@@ -1,7 +1,7 @@
 import { Fragment, cloneElement, isValidElement, type ReactNode } from "react";
 
-const SYMBOL_SPLIT_PATTERN = /([&+@_/()•©·"'‘’“”–—-])/g;
-const SYMBOL_ONLY_PATTERN = /^[&+@_/()•©·"'‘’“”–—-]$/;
+const SYMBOL_SPLIT_PATTERN = /([&+@_])/g;
+const SYMBOL_ONLY_PATTERN = /^[&+@_]$/;
 
 interface SafeTextProps {
   text: string;

--- a/src/index.css
+++ b/src/index.css
@@ -98,12 +98,13 @@
   font-family: system-ui, -apple-system, sans-serif;
 }
 
-/* Keep decorative brand fonts from substituting ornamental glyphs for common
-   punctuation in display headings and CMS-driven names. */
+/* Keep decorative brand fonts from substituting ornamental glyphs for the few
+   symbols they distort, while staying close to the site's editorial serif. */
 .font-symbol {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-style: normal;
-  font-weight: inherit;
+  font-family: Baskerville, "Libre Baskerville", Georgia, "Times New Roman", serif;
+  font-size: 0.82em;
+  font-style: italic;
+  font-weight: 400;
   letter-spacing: 0;
 }
 


### PR DESCRIPTION
## Summary
- Narrows `SafeText` so it no longer wraps quotes, apostrophes, dashes, parentheses, or other normal punctuation that already looks better in the brand display font.
- Replaces the heavy system-font symbol fallback with a smaller italic serif fallback for the remaining problematic symbols (`&`, `+`, `@`, `_`).
- Specifically avoids Balgin for the fallback because its ampersand renders as the visible DEMO/artifact glyph.

Follow-up to #91 / #105.

## Visual QA
- Rechecked the About heading so `"I Do"` stays in the display font instead of oversized system quotes.
- Rechecked the Inquiry heading so `Dates & Dreams` uses a softer serif ampersand instead of the heavy system ampersand or Balgin DEMO artifact.

## Tests
- `npm run build`
- `git diff --check`
