### PR TITLE
Fix About body font artifacts

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -37,7 +37,7 @@ export default function About() {
         <h2 className="text-5xl md:text-8xl text-femme-dark leading-tight italic">
           <SafeText text='Why We Obsess Over "I Do"' />
         </h2>
-        <div className="flex flex-col gap-5 text-femme-dark/80 text-lg md:text-xl leading-relaxed max-w-xl">
+        <div className="flex flex-col gap-5 text-femme-dark/80 text-lg md:text-xl leading-relaxed max-w-xl font-system">
           {aboutParagraphs.map((paragraph, index) => (
             <p key={index}>{paragraph}</p>
           ))}


### PR DESCRIPTION
## Summary
- Moves the About section body paragraphs to the existing `font-system` treatment.
- Keeps the display heading unchanged, but prevents The Seasons body font from rendering odd punctuation glyphs in the paragraph copy.

Follow-up to #91.

## Visual QA
- Rechecked the `Why We Obsess Over "I Do"` section in the local browser and confirmed the paragraph copy now uses `system-ui, -apple-system, sans-serif`.

## Tests
- `npm run build`
- `git diff --check`
