### PR TITLE
Hide Testimonials section until real testimonials are collected

### DIFF
--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -29,6 +29,12 @@ export default function Testimonials() {
     testimonials.length,
   );
 
+  // No real testimonials yet (empty CMS + empty fallback): hide the whole
+  // section instead of rendering an empty "Kind Words" header. It reappears
+  // automatically once entries are added in Sanity. Placed after all hooks so
+  // the Rules of Hooks are respected.
+  if (testimonials.length === 0) return null;
+
   return (
     <section className="py-16 md:py-24 px-6 md:px-24 bg-femme-pale">
       {/* Header row with arrow */}

--- a/src/data/testimonials.ts
+++ b/src/data/testimonials.ts
@@ -4,23 +4,10 @@ export interface Testimonial {
   detail: string;
 }
 
-export const testimonials: Testimonial[] = [
-  {
-    quote:
-      "Amanda made our day feel effortless. Every tiny detail we obsessed over for months just appeared — perfectly. We didn't lift a finger and somehow it was better than anything we'd imagined.",
-    name: "Priscila & Tri",
-    detail: "Atlanta, GA · Full Coordination + Design",
-  },
-  {
-    quote:
-      "Hiring Femme Events for day-of coordination was the best decision we made. Amanda kept everything moving without us ever feeling the pressure. Our guests still talk about how smooth it all was.",
-    name: "Kaitlyn & James",
-    detail: "Roswell, GA · Day-of Coordination",
-  },
-  {
-    quote:
-      "We were DIY-ing everything and totally overwhelmed. The partial planning package was exactly what we needed — vendor recommendations, mood boards, budget help. She got us across the finish line with our sanity intact.",
-    name: "Maya & Devon",
-    detail: "Decatur, GA · Partial Planning",
-  },
-];
+// Intentionally empty until real client testimonials are collected. Testimonials
+// are managed in Sanity (the "Testimonial" document type) so Amanda can add them
+// self-serve. While both this list and the CMS are empty, the Testimonials
+// section hides itself (see src/components/Testimonials.tsx) rather than showing
+// placeholder reviews. Adding entries in Sanity makes the section reappear
+// automatically — no code change or redeploy required.
+export const testimonials: Testimonial[] = [];

--- a/src/lib/testimonials.ts
+++ b/src/lib/testimonials.ts
@@ -19,7 +19,8 @@ export async function getTestimonials(): Promise<Testimonial[]> {
   if (!sanityClient) return fallbackTestimonials;
   try {
     const result = await sanityClient.fetch<Testimonial[]>(TESTIMONIALS_QUERY);
-    // Empty CMS = use fallback so the section never renders blank.
+    // Empty CMS falls back to the static list (currently empty). When both are
+    // empty the section hides itself rather than showing placeholder reviews.
     return result.length > 0 ? result : fallbackTestimonials;
   } catch {
     return fallbackTestimonials;


### PR DESCRIPTION
## Summary

The Testimonials ("Kind Words") section is already fully Sanity-wired, but it fell back to placeholder reviews in `src/data/testimonials.ts` whenever the CMS was empty — meaning the live site has been showing **fabricated** client testimonials. We have no production-ready testimonials yet.

This PR hides the section for now and makes it reappear **automatically** once real testimonials are added in Sanity — no further code change or redeploy needed.

## Changes

- `src/data/testimonials.ts` — empty the static fallback array (kept the `Testimonial` type and the Sanity-first data flow).
- `src/components/Testimonials.tsx` — render `null` when there are zero testimonials. The check is placed after all hooks run, so the Rules of Hooks are respected.
- `src/lib/testimonials.ts` — updated the now-stale fallback comment.

## Behavior

| State | Result |
|-------|--------|
| Empty CMS (today) | Section is hidden — no fake reviews |
| Amanda adds Testimonial docs in Sanity | Section reappears automatically (client-side fetch, no redeploy) |

## How Amanda adds testimonials later

Sanity Studio already has a **Testimonial** document type with fields: Couple/Client Name, Quote, Detail Line, optional Event Date, Display Order, and Photo. New entries show up live.

## Testing

- `npm run lint` (tsc --noEmit) — passes
- `npm run build` (vite build) — passes

Closes #115