### PR TITLE
fix: configure Vercel SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `vercel.json` SPA rewrite for Vite/React Router direct-route support.
- Keeps build, styling, copy, and components unchanged.

## Why
The first Vercel deployment succeeded, but direct requests to `/about`, `/services`, `/journal`, and `/what-happens-next` returned Vercel 404s. This rewrite lets Vercel serve `index.html` so React Router can handle those paths.

## Test Plan
- `npm run build`
- Vercel deployment verification after merge/deploy:
  - `/`
  - `/about`
  - `/services`
  - `/journal`
  - `/what-happens-next`

Closes #122
