### PR TITLE
fix: land inquiry CTAs on form anchor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ function ScrollToHash() {
     const scrollToTarget = () => {
       const el = document.getElementById(id);
       if (el) {
-        el.scrollIntoView();
+        el.scrollIntoView({ block: "start" });
         return;
       }
       if (attempts++ < 20) raf = requestAnimationFrame(scrollToTarget);

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -99,7 +99,7 @@ export default function FAQ() {
             Still not sure? Fill out an inquiry — no pressure, just conversation.
           </p>
           <a
-            href="#inquiry"
+            href="#inquiry-form"
             onClick={() => trackEvent("cta_inquiry_click", { location: "faq" })}
             className="inline-block mt-8 bg-femme-plum text-white px-8 py-3.5 rounded-full font-bold text-sm uppercase tracking-widest shadow-md hover:bg-femme-dark transition-colors duration-200 font-system"
           >

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -44,7 +44,7 @@ export default function Hero() {
           className="mt-14"
         >
           <motion.a
-            href="#inquiry"
+            href="#inquiry-form"
             onClick={() => trackEvent("cta_inquiry_click", { location: "hero" })}
             whileHover={{ scale: 1.05, backgroundColor: "var(--color-femme-deep)", boxShadow: "0 8px 28px rgba(131,22,84,0.5)" }}
             whileTap={{ scale: 0.97 }}

--- a/src/components/Inquiry.tsx
+++ b/src/components/Inquiry.tsx
@@ -152,7 +152,7 @@ export default function Inquiry() {
       </motion.div>
 
       <div className="mx-auto mt-16 grid max-w-6xl gap-12 md:grid-cols-[minmax(0,0.82fr)_minmax(420px,1fr)] md:items-start">
-        <div className="flex flex-col gap-6 md:sticky md:top-32">
+        <div id="inquiry-form" className="scroll-mt-28 flex flex-col gap-6 md:sticky md:top-32">
           <h2 className="text-6xl italic leading-[0.95] text-femme-dark md:text-8xl">
             <SafeText text="Ready to Chat Dates & Dreams?" />
           </h2>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -135,7 +135,7 @@ export default function Navbar() {
             Journal
           </NavLink>
           <a
-            href={anchor("#inquiry")}
+            href={anchor("#inquiry-form")}
             onClick={() => trackEvent("nav_inquiry_click", { location: "nav_desktop" })}
             className={linkClass}
           >
@@ -192,7 +192,7 @@ export default function Navbar() {
                 Journal
               </NavLink>
               <a
-                href={anchor("#inquiry")}
+                href={anchor("#inquiry-form")}
                 onClick={() => {
                   closeMenu();
                   trackEvent("nav_inquiry_click", { location: "nav_mobile" });

--- a/src/components/Process.tsx
+++ b/src/components/Process.tsx
@@ -124,7 +124,7 @@ export default function Process() {
         className="mt-16 md:mt-20 flex flex-col md:flex-row md:items-center gap-4 md:gap-6"
       >
         <a
-          href="#inquiry"
+          href="#inquiry-form"
           onClick={() => trackEvent("cta_inquiry_click", { location: "process" })}
           className="inline-block bg-femme-plum text-white px-10 py-4 rounded-full font-bold text-sm uppercase tracking-widest shadow-md hover:bg-femme-dark transition-colors duration-200 font-system"
         >

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -100,7 +100,7 @@ function ServiceCard({
   const navigate = useNavigate();
 
   // Carries the clicked package to the inquiry form via the URL, e.g.
-  // `/?service=the-full-femme#inquiry`, so the form can prefill it.
+  // `/?service=the-full-femme#inquiry-form`, so the form can prefill it.
   const inquiryHref = inquiryHrefForLabel(service.title);
 
   return (
@@ -186,11 +186,11 @@ function ServiceCard({
             e.preventDefault();
             trackEvent("cta_inquiry_click", { location: "service_card", service: service.title });
             navigate(inquiryHref);
-            // Scroll explicitly: switching packages while already at #inquiry is
-            // a search-only URL change, so ScrollToHash (keyed on pathname/hash)
-            // won't re-fire. The section always exists on the home page, and
-            // the global scroll-padding-top keeps it clear of the navbar.
-            document.getElementById("inquiry")?.scrollIntoView();
+            // Scroll explicitly: switching packages while already at the form
+            // anchor is a search-only URL change, so ScrollToHash (keyed on
+            // pathname/hash) won't re-fire. The dedicated form anchor keeps
+            // visitors from landing in the FAQ/introduction area.
+            document.getElementById("inquiry-form")?.scrollIntoView({ block: "start" });
           }}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}

--- a/src/components/Vendors.tsx
+++ b/src/components/Vendors.tsx
@@ -152,7 +152,7 @@ export default function Vendors() {
           Want recommendations for something not listed here?
         </p>
         <a
-          href="#inquiry"
+          href="#inquiry-form"
           onClick={() => trackEvent("cta_inquiry_click", { location: "vendors" })}
           className="inline-block px-8 py-3.5 text-sm font-bold uppercase tracking-widest font-system
             bg-femme-plum text-white border-2 border-femme-plum

--- a/src/data/serviceOptions.ts
+++ b/src/data/serviceOptions.ts
@@ -20,10 +20,10 @@ export const SERVICE_OPTIONS: ServiceOption[] = [
 // Neutral fallback for visitors who reach the form without picking a package.
 export const NOT_SURE_LABEL = "Not sure yet";
 
-/** Maps a card label to its CTA link, e.g. `/?service=the-full-femme#inquiry`. */
+/** Maps a card label to its CTA link, e.g. `/?service=the-full-femme#inquiry-form`. */
 export function inquiryHrefForLabel(label: string): string {
   const slug = SERVICE_OPTIONS.find((o) => o.label === label)?.slug;
-  return slug ? `/?service=${slug}#inquiry` : "#inquiry";
+  return slug ? `/?service=${slug}#inquiry-form` : "#inquiry-form";
 }
 
 /** Resolves a URL `?service=<slug>` value back to its display label, or "". */

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -86,7 +86,7 @@ export default function AboutPage() {
             </p>
           </div>
           <a
-            href="/#inquiry"
+            href="/#inquiry-form"
             className="inline-block rounded-full bg-femme-plum px-8 py-4 text-center text-sm font-bold uppercase tracking-widest text-white shadow-md transition-colors duration-200 hover:bg-femme-dark font-system"
           >
             Start Your Inquiry

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -201,7 +201,7 @@ export default function BlogPost() {
             We'd love to hear about your wedding. Fill out an inquiry and we'll be in touch within 48 hours.
           </p>
           <Link
-            to="/#inquiry"
+            to="/#inquiry-form"
             className="inline-block bg-femme-plum text-white px-8 py-3.5 rounded-full font-bold text-sm uppercase tracking-widest font-system hover:bg-femme-dark transition-colors duration-200 w-fit mt-2"
           >
             Get in Touch

--- a/src/pages/WhatHappensNext.tsx
+++ b/src/pages/WhatHappensNext.tsx
@@ -141,7 +141,7 @@ export default function WhatHappensNextPage() {
             </p>
           </div>
           <Link
-            to="/#inquiry"
+            to="/#inquiry-form"
             className="inline-block rounded-full bg-femme-plum px-8 py-4 text-center text-sm font-bold uppercase tracking-widest text-white shadow-md transition-colors duration-200 hover:bg-femme-dark font-system"
           >
             Start Your Journey


### PR DESCRIPTION
## Summary
- Adds a dedicated `#inquiry-form` anchor on the actual form title/field area.
- Routes inquiry CTAs from nav, hero, FAQ, process, vendors, blog, about, what-happens-next, and service cards to the form-specific anchor.
- Updates hash scrolling and service-card same-hash scrolling to use `block: "start"`.

## Root cause
The existing `#inquiry` target was the broader Inquiry section, which starts above the form after FAQ/intro content and layout shifts. CTA clicks therefore landed users in the section/FAQ area instead of directly on the form.

## Test plan
- `npm ci`
- `npm run lint`
- `npm run build`
- Local Playwright/mobile check from `/about` START YOUR INQUIRY: URL became `/#inquiry-form`; form anchor rendered at top of viewport area and first fields were visible.

Closes #125
