### PR TITLE
fix: serve grain texture locally

### DIFF
--- a/public/noise.svg
+++ b/public/noise.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160">
+  <filter id="grain" x="0" y="0" width="100%" height="100%">
+    <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="4" stitchTiles="stitch"/>
+    <feColorMatrix type="saturate" values="0"/>
+  </filter>
+  <rect width="160" height="160" filter="url(#grain)" opacity="0.65"/>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -121,7 +121,7 @@
   height: 100%;
   opacity: 0.05;
   pointer-events: none;
-  background-image: url("https://grainy-gradients.vercel.app/noise.svg");
+  background-image: url("/noise.svg");
   z-index: 1;
 }
 


### PR DESCRIPTION
## Summary
- Replaces the production dependency on `https://grainy-gradients.vercel.app/noise.svg` with a checked-in `/noise.svg` asset under `public/`.
- Keeps the existing `.grain-bg` visual treatment while removing the third-party 404 request.

## Root cause
The global grain CSS referenced an external decorative asset that currently returns 404 in production. Because the class is global, the missing asset can pollute console/network output on any page using the grain overlay.

## Test plan
- `npm ci`
- `npm run lint`
- `npm run build`
- Verified built CSS contains `/noise.svg` and no `grainy-gradients` reference.

Closes #126
