### PR TITLE
fix: prevent process carousel vertical scroll

### DIFF
--- a/src/components/Process.tsx
+++ b/src/components/Process.tsx
@@ -66,7 +66,7 @@ export default function Process() {
         <div
           ref={ref}
           className="flex md:grid md:grid-cols-4 gap-6
-            overflow-x-auto md:overflow-visible
+            overflow-x-auto overflow-y-hidden md:overflow-visible
             snap-x snap-mandatory md:snap-none
             scrollbar-hide
             -mx-6 md:mx-0 px-6 md:px-0


### PR DESCRIPTION
## Summary
- Explicitly hides vertical overflow on the mobile `What Happens Next` carousel while preserving horizontal overflow/snap scrolling.
- Leaves desktop grid overflow behavior unchanged.

## Root cause
The horizontal mobile carousel used `overflow-x-auto` without constraining Y overflow. With the card entry animation increasing scroll height, browsers exposed a small internal vertical scroll region.

## Test plan
- `npm ci`
- `npm run lint`
- `npm run build`
- Local Playwright/mobile check at 390x844: carousel computed `overflowY: hidden`; synthetic vertical wheel left carousel `scrollTop` at 0 while page scroll moved.

Closes #128
