### PR TITLE
fix: make Sanity reads fail fast so the Journal can't hang on loading (#124)

### DIFF
--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -8,5 +8,20 @@ const apiVersion = import.meta.env.VITE_SANITY_API_VERSION ?? "2024-01-01";
 // wiring) the client is null and the data layer falls back to the static
 // posts in src/data/posts.ts. PR B will populate this in Vercel.
 export const sanityClient: SanityClient | null = projectId
-  ? createClient({ projectId, dataset, apiVersion, useCdn: true })
+  ? createClient({
+      projectId,
+      dataset,
+      apiVersion,
+      useCdn: true,
+      // Fail fast on read errors so the UI degrades quickly. Every data
+      // helper (posts/vendors/testimonials) already falls back to static
+      // content on a rejected fetch, but the client has no request timeout
+      // by default and retries failed reads (maxRetries defaults to 5) with
+      // exponential back-off — so a blocked or stalled read can leave the
+      // Journal sitting on "Loading…" instead of reaching that fallback
+      // (see issue #124). timeout caps any single request; maxRetries: 0
+      // skips retrying a doomed public-CDN read.
+      maxRetries: 0,
+      timeout: 10000,
+    })
   : null;

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -15,12 +15,13 @@ export const sanityClient: SanityClient | null = projectId
       useCdn: true,
       // Fail fast on read errors so the UI degrades quickly. Every data
       // helper (posts/vendors/testimonials) already falls back to static
-      // content on a rejected fetch, but the client has no request timeout
-      // by default and retries failed reads (maxRetries defaults to 5) with
-      // exponential back-off — so a blocked or stalled read can leave the
-      // Journal sitting on "Loading…" instead of reaching that fallback
-      // (see issue #124). timeout caps any single request; maxRetries: 0
-      // skips retrying a doomed public-CDN read.
+      // content on a rejected fetch, but the client defaults to a long
+      // 5-minute request ceiling and retries failed reads (maxRetries
+      // defaults to 5) with exponential back-off — so a blocked or stalled
+      // read can leave the Journal sitting on "Loading…" instead of reaching
+      // that fallback (see issue #124). timeout lowers the per-request
+      // ceiling to 10 seconds; maxRetries: 0 skips retrying a doomed
+      // public-CDN read.
       maxRetries: 0,
       timeout: 10000,
     })


### PR DESCRIPTION
## Summary
Addresses the **"Journal stuck loading"** half of #124. Does **not** close the issue — the root-cause CORS 403 needs a Sanity-project config change (see below).

Refs #124

## Problem
On the live origin, Sanity CDN reads fail with a CORS 403 (`tc3rpyl9.apicdn.sanity.io`). The data helpers (`posts`/`vendors`/`testimonials`) already `try/catch → static fallback`, but the browser client:
- defaults to a **long 5-minute request ceiling**, and
- **retries failed reads** (`maxRetries` defaults to 5, exponential back-off).

So a blocked or stalled read can leave `/journal` sitting on `Loading the journal…` instead of reaching its static fallback. (`BlogIndex` gates the whole page behind `if (!posts) return Loading`.)

## Change
`src/lib/sanity.ts` — configure the client to fail fast:
- `timeout: 10000` — lowers the default 5-minute request ceiling to 10 seconds so a single read cannot stall the UI for minutes.
- `maxRetries: 0` — don't retry a doomed public-CDN read; surface the failure on the first attempt so the static fallback renders promptly.

Applies to all three data helpers, so the homepage vendor/testimonial sections degrade quickly too.

## Verification
- `npm run lint` (tsc --noEmit) — passes
- `npm run build` — passes
- Confirmed against the installed `@sanity/client@7.22.0` source that `maxRetries` defaults to 5 and `shouldRetry` short-circuits to `false` when `maxRetries === 0`.
- Timed a forced connection failure: `maxRetries:0` rejects in ~2 ms vs the default's retry path. (True browser-CORS timing can't be reproduced locally — `localhost` is allow-listed in Sanity — but the long timeout + retry mechanism is what delays the fallback.)

## ⚠️ Root cause still open (not fixable in-repo)
The live CMS data is blocked by **CORS**, which is a Sanity project setting, not code. Someone with **manage** access to project `tc3rpyl9` needs to allow-list the production origins (anonymous public reads → `--no-credentials`):

```bash
# from the studio/ directory, logged in with a manage-scoped account
npx sanity cors add https://femme-events-website.vercel.app --no-credentials
npx sanity cors add https://femmeevents.com --no-credentials
npx sanity cors add https://www.femmeevents.com --no-credentials
```

After that, live CMS data renders (this PR just ensures graceful, fast fallback until then and for any future read failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
