### PR TITLE
Fix mobile visual QA issues 134-143

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,19 +33,31 @@ function ScrollToHash() {
   useEffect(() => {
     if (!hash) return;
     const id = hash.slice(1);
-    let raf = 0;
+    let timeout = 0;
     let attempts = 0;
     const scrollToTarget = () => {
       const el = document.getElementById(id);
       if (el) {
         el.scrollIntoView({ block: "start" });
+        requestAnimationFrame(() => el.scrollIntoView({ block: "start" }));
         return;
       }
-      if (attempts++ < 20) raf = requestAnimationFrame(scrollToTarget);
+      if (attempts++ < 50) timeout = window.setTimeout(scrollToTarget, 50);
     };
-    raf = requestAnimationFrame(scrollToTarget);
-    return () => cancelAnimationFrame(raf);
+    timeout = window.setTimeout(scrollToTarget, 0);
+    return () => window.clearTimeout(timeout);
   }, [pathname, hash]);
+  return null;
+}
+
+// Browser history keeps the current scroll position across SPA route changes.
+// Reset ordinary route navigations while leaving hash links to ScrollToHash.
+function ScrollToRouteTop() {
+  const { pathname, search, hash } = useLocation();
+  useEffect(() => {
+    if (hash) return;
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, [pathname, search, hash]);
   return null;
 }
 
@@ -78,6 +90,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <RouteAnalytics />
+      <ScrollToRouteTop />
       <ScrollToHash />
       <Navbar />
       <Suspense fallback={<div className="min-h-screen bg-femme-cream" />}>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -67,9 +67,9 @@ export default function Hero() {
           <span className="text-[10px] md:text-xs uppercase tracking-widest opacity-75">Location</span>
           <span className="text-base md:text-xl font-medium drop-shadow-md">Atlanta, GA</span>
         </div>
-        <div className="flex flex-col gap-1.5 md:gap-2 text-right md:text-center">
+        <div className="flex min-w-0 flex-col gap-1.5 text-right md:gap-2 md:text-center">
           <span className="text-[10px] md:text-xs uppercase tracking-widest opacity-75">Email</span>
-          <span className="text-sm md:text-xl font-medium drop-shadow-md break-all md:break-normal font-system">
+          <span className="whitespace-nowrap text-[13px] font-medium drop-shadow-md md:text-xl font-system">
             Amanda@FemmeEvents.com
           </span>
         </div>

--- a/src/components/Inquiry.tsx
+++ b/src/components/Inquiry.tsx
@@ -88,7 +88,7 @@ export default function Inquiry() {
       <section id="inquiry" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender grid md:grid-cols-2 gap-16 items-center">
         <div className="flex flex-col gap-6">
           <h2 className="text-6xl md:text-8xl text-femme-dark leading-[0.95] italic">
-            <SafeText text="Ready to Chat Dates & Dreams?" />
+            <SafeText text="Ready to Chat Dates and Dreams?" />
           </h2>
           <p className="text-femme-dark/70 text-xl font-system">
             Drop us a line and let&apos;s see if your calendar and our magic align.
@@ -154,7 +154,7 @@ export default function Inquiry() {
       <div className="mx-auto mt-16 grid max-w-6xl gap-12 md:grid-cols-[minmax(0,0.82fr)_minmax(420px,1fr)] md:items-start">
         <div id="inquiry-form" className="scroll-mt-28 flex flex-col gap-6 md:sticky md:top-32">
           <h2 className="text-6xl italic leading-[0.95] text-femme-dark md:text-8xl">
-            <SafeText text="Ready to Chat Dates & Dreams?" />
+            <SafeText text="Ready to Chat Dates and Dreams?" />
           </h2>
           <p className="text-xl text-femme-dark/70 font-system">
             Drop us a line and let&apos;s see if your calendar and our magic align.

--- a/src/components/Process.tsx
+++ b/src/components/Process.tsx
@@ -69,7 +69,7 @@ export default function Process() {
             overflow-x-auto overflow-y-hidden md:overflow-visible
             snap-x snap-mandatory md:snap-none
             scrollbar-hide
-            -mx-6 md:mx-0 px-6 md:px-0
+            md:mx-0 md:px-0
             pb-2 md:pb-0
             relative z-10"
         >
@@ -80,7 +80,7 @@ export default function Process() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: index * 0.15, duration: 0.6, ease: "easeOut" }}
-              className="flex flex-col gap-5 shrink-0 w-[85vw] md:w-auto snap-start md:snap-align-none"
+              className="flex w-[78vw] shrink-0 snap-start flex-col gap-5 md:w-auto md:snap-align-none"
             >
               {/* Number badge */}
               <div className="w-20 h-20 rounded-full border-2 border-femme-plum flex items-center justify-center shrink-0 bg-femme-cream">
@@ -126,7 +126,7 @@ export default function Process() {
         <a
           href="#inquiry-form"
           onClick={() => trackEvent("cta_inquiry_click", { location: "process" })}
-          className="inline-block bg-femme-plum text-white px-10 py-4 rounded-full font-bold text-sm uppercase tracking-widest shadow-md hover:bg-femme-dark transition-colors duration-200 font-system"
+          className="inline-flex items-center justify-center bg-femme-plum text-white px-10 py-4 rounded-full font-bold text-sm uppercase tracking-widest leading-none shadow-md hover:bg-femme-dark transition-colors duration-200 font-system"
         >
           Start Your Journey
         </a>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -112,7 +112,7 @@ function ServiceCard({
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ delay: index * 0.15, duration: 0.6, ease: "easeOut" }}
-      className={`relative shrink-0 w-[85vw] md:w-auto ${isFullFemme ? "h-[760px]" : "h-[640px]"} md:h-[700px] snap-center md:snap-align-none rounded-2xl overflow-hidden cursor-pointer shadow-xl`}
+      className="relative h-[700px] w-[85vw] shrink-0 snap-center overflow-hidden rounded-2xl shadow-xl cursor-pointer md:h-[700px] md:w-auto md:snap-align-none"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
@@ -141,7 +141,7 @@ function ServiceCard({
       <div className="absolute inset-0 bg-femme-dark/30 md:hidden" />
 
       {/* Card content */}
-      <div className="absolute inset-0 flex flex-col justify-end p-8">
+      <div className="absolute inset-0 flex flex-col justify-end p-6 md:p-8">
         {/* Mobile: includes always visible — no hover state on touch */}
         <div className="md:hidden">
           <IncludesList service={service} compact={isFullFemme} />
@@ -166,7 +166,7 @@ function ServiceCard({
         {/* Title block — always visible */}
         <div className="mb-5">
           <h3
-            className="text-white text-5xl md:text-6xl leading-tight mb-2"
+            className="mb-2 text-[2.85rem] leading-tight text-white md:text-6xl"
             style={{ fontFamily: "Frunchy Sage, serif", fontWeight: "bold" }}
           >
             <SafeText text={service.title} />
@@ -216,7 +216,7 @@ export default function Services() {
   );
 
   return (
-    <section id="services" className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender">
+    <section className="py-16 md:py-24 px-6 md:px-24 bg-femme-lavender">
       {/* Header */}
       <div className="mb-16">
         <h2 className="text-5xl md:text-8xl text-femme-dark leading-tight italic mb-6">
@@ -244,12 +244,14 @@ export default function Services() {
           snap-centered card balanced in the viewport on mobile. Desktop
           resets to the section's own padding via md:px-0. */}
       <div
+        id="services"
         ref={ref}
         className="flex md:grid md:grid-cols-3 gap-6
           overflow-x-auto md:overflow-visible
           snap-x snap-mandatory md:snap-none
           scrollbar-hide
           -mx-6 md:mx-0 px-[7.5vw] md:px-0
+          scroll-mt-28 md:scroll-mt-32
           pb-2 md:pb-0"
       >
         {services.map((service, i) => (

--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -6,6 +6,7 @@ export interface Post {
   date: string;
   readTime: string;
   image: string;
+  imagePosition?: string;
   body: string;
 }
 
@@ -19,6 +20,7 @@ export const posts: Post[] = [
     date: "April 10, 2026",
     readTime: "5 min read",
     image: "/photos/pt2.jpg",
+    imagePosition: "50% 56%",
     body: `
 Six months feels like forever — until it doesn't. If you're sitting at the six-month mark and your to-do list looks like a CVS receipt, take a breath. Not everything on it matters equally.
 
@@ -68,6 +70,7 @@ If you're not sure what your "right order" looks like — that's exactly what a 
     date: "March 28, 2026",
     readTime: "4 min read",
     image: "/photos/pt3.jpg",
+    imagePosition: "52% 72%",
     body: `
 The phrase "day-of coordination" is genuinely misleading. We've thought about lobbying to change the industry term. We haven't won that fight yet.
 
@@ -114,6 +117,7 @@ Not sure which package fits your situation? Fill out our inquiry form and we'll 
     date: "March 14, 2026",
     readTime: "6 min read",
     image: "/photos/kj1.jpg",
+    imagePosition: "50% 42%",
     body: `
 Venue tours are designed to make you fall in love. They happen on sunny days, rooms are staged perfectly, and your tour guide has done this hundreds of times. Their job is to sell.
 

--- a/src/index.css
+++ b/src/index.css
@@ -99,13 +99,15 @@
 }
 
 /* Keep decorative brand fonts from substituting ornamental glyphs for the few
-   symbols they distort, while staying close to the site's editorial serif. */
+   symbols they distort. */
 .font-symbol {
-  font-family: Baskerville, "Libre Baskerville", Georgia, "Times New Roman", serif;
-  font-size: 0.82em;
-  font-style: italic;
-  font-weight: 400;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.72em;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1;
   letter-spacing: 0;
+  vertical-align: 0.04em;
 }
 
 /* ─── Grain Texture ────────────────────────────── */

--- a/src/lib/imageUrl.ts
+++ b/src/lib/imageUrl.ts
@@ -11,6 +11,11 @@ interface SanityImageOpts {
   fit?: "max" | "crop";
 }
 
+interface SanityHotspot {
+  x?: number;
+  y?: number;
+}
+
 export function isSanityUrl(url: string | undefined): url is string {
   return typeof url === "string" && url.includes(SANITY_HOST);
 }
@@ -57,4 +62,16 @@ export function parseSanityDimensions(
   const match = /-(\d+)x(\d+)\.[a-zA-Z0-9]+(?:\?|$)/.exec(url);
   if (!match) return null;
   return { width: Number(match[1]), height: Number(match[2]) };
+}
+
+export function imageObjectPosition(
+  fallbackPosition?: string,
+  hotspot?: SanityHotspot,
+): string | undefined {
+  if (hotspot?.x !== undefined && hotspot?.y !== undefined) {
+    const x = Math.min(100, Math.max(0, hotspot.x * 100));
+    const y = Math.min(100, Math.max(0, hotspot.y * 100));
+    return `${x.toFixed(2)}% ${y.toFixed(2)}%`;
+  }
+  return fallbackPosition;
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -7,6 +7,10 @@ import { posts as fallbackPosts, type Post as FallbackPost } from "../data/posts
 // Both are renderable by BlogPost.tsx; the renderer branches on shape.
 export interface Post extends Omit<FallbackPost, "body"> {
   body: string | PortableTextBlock[];
+  imageHotspot?: {
+    x?: number;
+    y?: number;
+  };
 }
 
 const POSTS_QUERY = `*[_type == "post"] | order(date desc){
@@ -17,6 +21,7 @@ const POSTS_QUERY = `*[_type == "post"] | order(date desc){
   date,
   readTime,
   "image": image.asset->url,
+  "imageHotspot": image.hotspot,
   body
 }`;
 
@@ -28,6 +33,7 @@ const POST_QUERY = `*[_type == "post" && slug.current == $slug][0]{
   date,
   readTime,
   "image": image.asset->url,
+  "imageHotspot": image.hotspot,
   body
 }`;
 

--- a/src/lib/useCarouselIndex.ts
+++ b/src/lib/useCarouselIndex.ts
@@ -44,17 +44,19 @@ export function useCarouselIndex<T extends HTMLElement = HTMLDivElement>(
     const prefersReducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
-    // Center the target card in the scrollport so dot navigation lands on
-    // the same position a swipe produces with `scroll-snap-align: center`.
+    // Match the card's CSS snap alignment so dot navigation lands where a
+    // swipe would settle.
     // `offsetLeft` is measured from the shared offset parent, so subtracting
-    // the container's own offset yields the card's left edge within the
-    // scroll content; the half-leftover term then centers it. Clamp to the
-    // valid scroll range so the first/last cards don't try to overscroll.
-    const center =
-      card.offsetLeft - el.offsetLeft - (el.clientWidth - card.clientWidth) / 2;
+    // the container's own offset yields the card's left edge within the scroll
+    // content. Clamp to the valid scroll range so edge cards don't overscroll.
+    const align = getComputedStyle(card).scrollSnapAlign;
+    const leftEdge = card.offsetLeft - el.offsetLeft;
+    const target = align.includes("center")
+      ? leftEdge - (el.clientWidth - card.clientWidth) / 2
+      : leftEdge;
     const maxScroll = el.scrollWidth - el.clientWidth;
     el.scrollTo({
-      left: Math.max(0, Math.min(center, maxScroll)),
+      left: Math.max(0, Math.min(target, maxScroll)),
       behavior: prefersReducedMotion ? "auto" : "smooth",
     });
   };

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -85,12 +85,12 @@ export default function AboutPage() {
               Tell us about your wedding and we'll take it from there.
             </p>
           </div>
-          <a
-            href="/#inquiry-form"
-            className="inline-block rounded-full bg-femme-plum px-8 py-4 text-center text-sm font-bold uppercase tracking-widest text-white shadow-md transition-colors duration-200 hover:bg-femme-dark font-system"
+          <Link
+            to="/#inquiry-form"
+            className="inline-flex items-center justify-center rounded-full bg-femme-plum px-8 py-4 text-center text-sm font-bold uppercase tracking-widest leading-none text-white shadow-md transition-colors duration-200 hover:bg-femme-dark font-system"
           >
             Start Your Inquiry
-          </a>
+          </Link>
         </motion.div>
       </section>
     </main>

--- a/src/pages/BlogIndex.tsx
+++ b/src/pages/BlogIndex.tsx
@@ -6,6 +6,7 @@ import { getInitialPosts, getPosts, formatPostDate, type Post } from "../lib/pos
 import SafeText from "../components/SafeText";
 import {
   buildSrcSet,
+  imageObjectPosition,
   parseSanityDimensions,
   sanityImageUrl,
 } from "../lib/imageUrl";
@@ -15,6 +16,7 @@ const CARD_WIDTHS = [400, 600, 800, 1200];
 
 function FeaturedPost({ post }: { post: Post }) {
   const dims = parseSanityDimensions(post.image);
+  const objectPosition = imageObjectPosition(post.imagePosition, post.imageHotspot);
   return (
     <motion.article
       initial={{ opacity: 0, y: 24 }}
@@ -34,6 +36,7 @@ function FeaturedPost({ post }: { post: Post }) {
           fetchPriority="high"
           decoding="async"
           className="w-full h-full object-cover"
+          style={objectPosition ? { objectPosition } : undefined}
         />
       </div>
 
@@ -67,6 +70,7 @@ function FeaturedPost({ post }: { post: Post }) {
 
 function PostCard({ post, index }: { post: Post; index: number }) {
   const dims = parseSanityDimensions(post.image);
+  const objectPosition = imageObjectPosition(post.imagePosition, post.imageHotspot);
   return (
     <motion.article
       layout
@@ -77,7 +81,7 @@ function PostCard({ post, index }: { post: Post; index: number }) {
       className="group flex flex-col gap-4 border-b border-femme-plum/10 pb-10"
     >
       {/* Image */}
-      <div className="overflow-hidden rounded-xl aspect-[16/5.04]">
+      <div className="overflow-hidden rounded-xl aspect-[4/3] sm:aspect-[16/9]">
         <img
           src={sanityImageUrl(post.image, { w: 800 })}
           srcSet={buildSrcSet(post.image, CARD_WIDTHS)}
@@ -88,6 +92,7 @@ function PostCard({ post, index }: { post: Post; index: number }) {
           loading="lazy"
           decoding="async"
           className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          style={objectPosition ? { objectPosition } : undefined}
         />
       </div>
 

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -6,6 +6,7 @@ import { PortableText, type PortableTextComponents } from "@portabletext/react";
 import { getInitialPost, getPost, formatPostDate, type Post } from "../lib/posts";
 import {
   buildSrcSet,
+  imageObjectPosition,
   parseSanityDimensions,
   sanityImageUrl,
 } from "../lib/imageUrl";
@@ -115,6 +116,7 @@ export default function BlogPost() {
   if (post === null) return <Navigate to="/journal" replace />;
 
   const heroDims = parseSanityDimensions(post.image);
+  const heroObjectPosition = imageObjectPosition(post.imagePosition, post.imageHotspot);
 
   return (
     <div className="min-h-screen bg-femme-cream">
@@ -130,6 +132,7 @@ export default function BlogPost() {
           fetchPriority="high"
           decoding="async"
           className="w-full h-full object-cover object-center"
+          style={heroObjectPosition ? { objectPosition: heroObjectPosition } : undefined}
         />
         <div className="absolute inset-0 bg-gradient-to-t from-femme-dark/70 via-femme-dark/20 to-transparent" />
       </div>

--- a/src/pages/WhatHappensNext.tsx
+++ b/src/pages/WhatHappensNext.tsx
@@ -142,7 +142,7 @@ export default function WhatHappensNextPage() {
           </div>
           <Link
             to="/#inquiry-form"
-            className="inline-block rounded-full bg-femme-plum px-8 py-4 text-center text-sm font-bold uppercase tracking-widest text-white shadow-md transition-colors duration-200 hover:bg-femme-dark font-system"
+            className="inline-flex items-center justify-center rounded-full bg-femme-plum px-8 py-4 text-center text-sm font-bold uppercase tracking-widest leading-none text-white shadow-md transition-colors duration-200 hover:bg-femme-dark font-system"
           >
             Start Your Journey
           </Link>


### PR DESCRIPTION
## Summary

- Fixed route scroll restoration so normal route changes open at the top, while hash links retry after render and still land on their target.
- Moved the Services hash target to the carousel, tightened mobile carousel spacing, normalized mobile service card heights, and centered CTA labels with flex alignment.
- Cleaned up the SafeText symbol fallback, hero email wrapping, and Journal image crops/aspect ratios with Sanity hotspot support plus fallback object positions.

## Before QA

- #134: Live 390px Inquiry screenshot showed the heading ampersand as the decorative display glyph. Desktop Inquiry showed the same oversized serif symbol.
- #135: Live Process CTA used `inline-block`; visual pass showed the label sitting optically low/off-center in the pill.
- #136: Live 390px Process carousel had the scroller and first card at `left: 0`, flush to the viewport.
- #137: Live service cards measured `640/640/760px` tall at 390px, with The Full Femme visibly taller; same mismatch reproduced at 375px and 430px.
- #138: From the bottom of the homepage, desktop nav Journal opened `/journal` at `scrollY=1082`.
- #139: Live older Journal card thumbnails used a very wide crop: mobile old-post cards measured about `327x103`, and desktop cards about `513x161`.
- #140: From `/about`, Services landed on the outer section/header area instead of the carousel cards.
- #141: About CTA did reach `/#inquiry-form`, but hash scrolling depended on the existing short retry behavior.
- #142: From the bottom of the homepage, desktop nav About opened `/about` at `scrollY=1060`.
- #143: Live 390px hero email used `word-break: break-all`, measured 40px tall, and rendered on two lines.

## After QA

- #134: Local 390px and desktop Inquiry checks confirm the heading now reads `Ready to Chat Dates and Dreams?`, removing the ampersand from both Inquiry heading instances entirely.
- #135: Process and What Happens Next CTAs now render as `inline-flex` with `align-items: center`, `justify-content: center`, and `line-height: 14px`.
- #136: Local 390px Process carousel first card now starts at `left: 24`, the scroller starts at `left: 24`, and Planning Steps dot 4 moved to slide 4.
- #137: Service cards now measure `700/700/700px` tall at 375px, 390px, and 430px; Service Packages dot 3 moved to The Full Femme and its included services remained readable.
- #138: Desktop and mobile nav Journal from the bottom now open `/journal` at `scrollY=0`.
- #139: Journal thumbnails now use less extreme responsive aspect ratios: mobile old-post cards measure about `327x245`, desktop cards about `513x288`, and older post hero images remain `object-cover` without stretching.
- #140: Desktop Services from `/about` lands with carousel cards visible near the top (`#services` cards at about 240px); mobile menu Services also brings the carousel into view.
- #141: About page Start Your Inquiry lands directly on the inquiry form on desktop (`top: 128`) and mobile (`top: 208`).
- #142: Desktop and mobile nav About from the bottom now open `/about` at `scrollY=0`.
- #143: Hero email now uses `white-space: nowrap`, `word-break: normal`, renders as a single 20px-tall line at 390px, and all checked mobile routes report no horizontal overflow.

Mobile widths checked: 375px, 390px, 430px. Desktop checked: 1280px wide. Screenshots and JSON notes were recorded locally under `/tmp/femme-qa-134-143`.

## Validation

- `npm run lint` passed.
- `npm run build` passed. Vite emitted the existing chunk-size warning only.
- `git diff --check` passed.

Fixes #134
Fixes #135
Fixes #136
Fixes #137
Fixes #138
Fixes #139
Fixes #140
Fixes #141
Fixes #142
Fixes #143

