### PR TITLE
fix: stop showing placeholder journal posts when CMS is empty (#152)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,17 @@
 VITE_FORMSPREE_ENDPOINT=
 
 # Sanity CMS (journal/blog backend — see issue #21)
-# Leave VITE_SANITY_PROJECT_ID unset to fall back to the static posts in
-# src/data/posts.ts. Once the Sanity project exists, paste its ID here
-# and in Vercel env vars.
+# When VITE_SANITY_PROJECT_ID is set, the Journal is fully CMS-driven: an
+# empty or failed read shows an intentional empty state, never static posts.
+# Once the Sanity project exists, paste its ID here and in Vercel env vars.
 VITE_SANITY_PROJECT_ID=
 VITE_SANITY_DATASET=production
 VITE_SANITY_API_VERSION=2024-01-01
+
+# Local dev only: when Sanity is NOT configured (VITE_SANITY_PROJECT_ID unset),
+# set this to "true" to seed the Journal with the demo posts in
+# src/data/posts.ts. These never appear on the public site (issue #152).
+VITE_USE_DEMO_POSTS=
 
 # Analytics (issue #15) — privacy-conscious. Provider-agnostic: set EITHER
 # Plausible OR GA4 (or both). Leave all three unset to disable analytics

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -37,18 +37,29 @@ const POST_QUERY = `*[_type == "post" && slug.current == $slug][0]{
   body
 }`;
 
-// Sync helpers for the initial render: when Sanity is disabled we resolve
-// from the static fallback immediately, preserving today's no-flash UX.
-// When Sanity is enabled, the initial render returns the "still loading"
-// shape and the async fetch fills in.
+// The static posts in src/data/posts.ts are demo/seed data only. They must
+// never appear on the public website (where Sanity is always configured) —
+// see issue #152. They are used solely for local development when Sanity is
+// not wired up AND the developer explicitly opts in via VITE_USE_DEMO_POSTS.
+const demoPosts: Post[] =
+  !sanityClient && import.meta.env.VITE_USE_DEMO_POSTS === "true"
+    ? fallbackPosts
+    : [];
+
+// Sync helpers for the initial render:
+// - Sanity enabled  → return the "still loading" shape (null / undefined);
+//   the async fetch fills in the real result.
+// - Sanity disabled → resolve from the demo seed immediately (empty unless
+//   the developer opted in), preserving the no-flash UX without ever
+//   surfacing placeholders on the public site.
 
 export function getInitialPosts(): Post[] | null {
-  return sanityClient ? null : fallbackPosts;
+  return sanityClient ? null : demoPosts;
 }
 
 export function getInitialPost(slug: string): Post | null | undefined {
   if (sanityClient) return undefined;
-  return fallbackPosts.find((p) => p.slug === slug) ?? null;
+  return demoPosts.find((p) => p.slug === slug) ?? null;
 }
 
 export function formatPostDate(date: string): string {
@@ -66,21 +77,25 @@ export function formatPostDate(date: string): string {
 }
 
 export async function getPosts(): Promise<Post[]> {
-  if (!sanityClient) return fallbackPosts;
+  if (!sanityClient) return demoPosts;
   try {
     return await sanityClient.fetch<Post[]>(POSTS_QUERY);
   } catch {
-    return fallbackPosts;
+    // CMS configured but unreachable: treat as "no journal posts yet" rather
+    // than surfacing static placeholders on the public site (issue #152).
+    return [];
   }
 }
 
 export async function getPost(slug: string): Promise<Post | null> {
   if (!sanityClient) {
-    return fallbackPosts.find((p) => p.slug === slug) ?? null;
+    return demoPosts.find((p) => p.slug === slug) ?? null;
   }
   try {
     return await sanityClient.fetch<Post | null>(POST_QUERY, { slug });
   } catch {
-    return fallbackPosts.find((p) => p.slug === slug) ?? null;
+    // CMS configured but unreachable: don't render the static placeholder for
+    // an old slug — let the caller redirect to /journal (issue #152).
+    return null;
   }
 }

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -4,24 +4,25 @@ const projectId = import.meta.env.VITE_SANITY_PROJECT_ID;
 const dataset = import.meta.env.VITE_SANITY_DATASET ?? "production";
 const apiVersion = import.meta.env.VITE_SANITY_API_VERSION ?? "2024-01-01";
 
-// When VITE_SANITY_PROJECT_ID is unset (dev / preview deploys without CMS
-// wiring) the client is null and the data layer falls back to the static
-// posts in src/data/posts.ts. PR B will populate this in Vercel.
+// When VITE_SANITY_PROJECT_ID is unset (local dev without CMS wiring) the
+// client is null. Public content then resolves to an empty state — the static
+// posts in src/data/posts.ts are only used as a local dev seed when
+// VITE_USE_DEMO_POSTS is also "true" (see src/lib/posts.ts, issue #152).
+// Production / preview deploys always set the project ID in Vercel env vars.
 export const sanityClient: SanityClient | null = projectId
   ? createClient({
       projectId,
       dataset,
       apiVersion,
       useCdn: true,
-      // Fail fast on read errors so the UI degrades quickly. Every data
-      // helper (posts/vendors/testimonials) already falls back to static
-      // content on a rejected fetch, but the client defaults to a long
-      // 5-minute request ceiling and retries failed reads (maxRetries
+      // Fail fast on read errors so the UI degrades quickly. Each data helper
+      // resolves a rejected fetch to a graceful state (posts → empty Journal;
+      // vendors/testimonials → static content), but the client defaults to a
+      // long 5-minute request ceiling and retries failed reads (maxRetries
       // defaults to 5) with exponential back-off — so a blocked or stalled
       // read can leave the Journal sitting on "Loading…" instead of reaching
-      // that fallback (see issue #124). timeout lowers the per-request
-      // ceiling to 10 seconds; maxRetries: 0 skips retrying a doomed
-      // public-CDN read.
+      // that state (see issue #124). timeout lowers the per-request ceiling to
+      // 10 seconds; maxRetries: 0 skips retrying a doomed public-CDN read.
       maxRetries: 0,
       timeout: 10000,
     })

--- a/src/pages/BlogIndex.tsx
+++ b/src/pages/BlogIndex.tsx
@@ -150,7 +150,8 @@ export default function BlogIndex() {
     [posts],
   );
 
-  if (!posts || posts.length === 0) {
+  // posts === null → Sanity fetch still in flight (loading).
+  if (posts === null) {
     return (
       <div className="min-h-screen bg-femme-cream pt-40 px-6 md:px-24">
         <p className="text-femme-dark/40 font-system">Loading the journal…</p>
@@ -158,6 +159,8 @@ export default function BlogIndex() {
     );
   }
 
+  // posts.length === 0 → intentional empty Journal (no CMS posts yet).
+  const isEmpty = posts.length === 0;
   const featured = posts[0];
   const rest = posts.slice(1);
   const filtered = activeCategory === "All"
@@ -189,64 +192,92 @@ export default function BlogIndex() {
         </motion.div>
       </section>
 
-      {/* Featured post */}
-      <section className="py-14 px-6 md:px-24">
-        <p className="text-xs uppercase tracking-widest font-bold text-femme-dark/35 font-system mb-6">
-          Latest Story
-        </p>
-        <FeaturedPost post={featured} />
-      </section>
-
-      {/* Category filter + grid */}
-      <section className="px-6 md:px-24 pb-24">
-        {/* Divider + filter */}
-        <div className="flex flex-wrap items-center gap-2 border-t border-femme-plum/10 pt-10 mb-12">
-          <p className="text-xs uppercase tracking-widest font-bold text-femme-dark/35 font-system mr-4">
-            Browse by
-          </p>
-          {categories.map((cat) => (
-            <button
-              key={cat}
-              onClick={() => setActiveCategory(cat)}
-              className={`px-5 py-2 rounded-full text-xs font-bold uppercase tracking-widest font-system transition-colors duration-200 cursor-pointer border ${
-                activeCategory === cat
-                  ? "bg-femme-plum text-white border-femme-plum"
-                  : "bg-transparent text-femme-dark/55 border-femme-dark/15 hover:border-femme-plum hover:text-femme-plum"
-              }`}
+      {isEmpty ? (
+        /* Intentional empty state — Journal exists but has no posts yet. */
+        <section className="py-24 px-6 md:px-24 text-center">
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, ease: "easeOut" }}
+            className="max-w-xl mx-auto flex flex-col items-center gap-5"
+          >
+            <h2 className="text-4xl md:text-5xl text-femme-dark italic leading-tight">
+              New stories are on the way
+            </h2>
+            <p className="text-femme-dark/55 text-lg font-system leading-relaxed">
+              We're putting together honest planning advice and real wedding
+              stories. Check back soon — there's plenty coming.
+            </p>
+            <Link
+              to="/#inquiry-form"
+              className="inline-flex items-center gap-2 text-femme-plum font-bold text-sm uppercase tracking-widest font-system hover:gap-4 transition-all duration-200 mt-2"
             >
-              {cat}
-            </button>
-          ))}
-        </div>
+              Start Planning With Us <ArrowRight size={15} strokeWidth={2.5} />
+            </Link>
+          </motion.div>
+        </section>
+      ) : (
+        <>
+          {/* Featured post */}
+          <section className="py-14 px-6 md:px-24">
+            <p className="text-xs uppercase tracking-widest font-bold text-femme-dark/35 font-system mb-6">
+              Latest Story
+            </p>
+            <FeaturedPost post={featured} />
+          </section>
 
-        {/* Post grid */}
-        <AnimatePresence mode="wait">
-          {filtered.length > 0 ? (
-            <motion.div
-              key={activeCategory}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.25 }}
-              className="grid md:grid-cols-2 gap-x-12 gap-y-0"
-            >
-              {filtered.map((post, index) => (
-                <PostCard key={post.slug} post={post} index={index} />
+          {/* Category filter + grid */}
+          <section className="px-6 md:px-24 pb-24">
+            {/* Divider + filter */}
+            <div className="flex flex-wrap items-center gap-2 border-t border-femme-plum/10 pt-10 mb-12">
+              <p className="text-xs uppercase tracking-widest font-bold text-femme-dark/35 font-system mr-4">
+                Browse by
+              </p>
+              {categories.map((cat) => (
+                <button
+                  key={cat}
+                  onClick={() => setActiveCategory(cat)}
+                  className={`px-5 py-2 rounded-full text-xs font-bold uppercase tracking-widest font-system transition-colors duration-200 cursor-pointer border ${
+                    activeCategory === cat
+                      ? "bg-femme-plum text-white border-femme-plum"
+                      : "bg-transparent text-femme-dark/55 border-femme-dark/15 hover:border-femme-plum hover:text-femme-plum"
+                  }`}
+                >
+                  {cat}
+                </button>
               ))}
-            </motion.div>
-          ) : (
-            <motion.p
-              key="empty"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              className="text-femme-dark/40 font-system py-16 text-center"
-            >
-              No posts in this category yet — check back soon.
-            </motion.p>
-          )}
-        </AnimatePresence>
-      </section>
+            </div>
+
+            {/* Post grid */}
+            <AnimatePresence mode="wait">
+              {filtered.length > 0 ? (
+                <motion.div
+                  key={activeCategory}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.25 }}
+                  className="grid md:grid-cols-2 gap-x-12 gap-y-0"
+                >
+                  {filtered.map((post, index) => (
+                    <PostCard key={post.slug} post={post} index={index} />
+                  ))}
+                </motion.div>
+              ) : (
+                <motion.p
+                  key="empty"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  className="text-femme-dark/40 font-system py-16 text-center"
+                >
+                  No posts in this category yet — check back soon.
+                </motion.p>
+              )}
+            </AnimatePresence>
+          </section>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Stops static placeholder journal posts from appearing on the public site when Sanity has no posts (or is unreachable), and replaces the endless "Loading the journal…" screen with an intentional empty state. The Journal route, nav, branding, and Sanity-backed rendering are all preserved for real posts.

Closes #152

## Changes
- **`src/lib/posts.ts`** — The static posts in `src/data/posts.ts` are now demo/seed data only, gated behind `VITE_USE_DEMO_POSTS === "true"` **and** an absent Sanity client (local dev only). When Sanity is configured:
  - `getPosts()` returns `[]` on an empty or failed read (no placeholder fallback).
  - `getPost(slug)` returns `null` on a failed read or unknown slug (no placeholder fallback).
- **`src/pages/BlogIndex.tsx`** — Splits loading vs. empty:
  - `posts === null` → loading.
  - `posts.length === 0` → branded, intentional empty state ("New stories are on the way") with an inquiry CTA, instead of a perpetual loader.
- **`src/pages/BlogPost.tsx`** — Unchanged. With the `getPost` change, an unknown/old placeholder slug now resolves to `null` and the existing `<Navigate to="/journal" replace />` redirects gracefully.

## Acceptance criteria
- [x] Sanity configured + returns `[]` → `/journal` shows the empty state, no placeholders.
- [x] Sanity configured + old placeholder slug requested → redirects to `/journal`, no static post rendered.
- [x] `/journal` has a graceful empty state instead of an endless loader.
- [x] Real Sanity posts render normally on index and detail.
- [x] Journal nav/link remains available.
- [x] No public placeholder fallback unless explicitly opted in as local demo data.

## Validation
- `npm run lint` (tsc --noEmit) — passes.
- `npm run build` — passes.
- Behavior reasoned through for: Sanity empty `[]`, Sanity with posts, and Sanity unconfigured/unreachable in local dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)