### PR TITLE
feat: add phone number field to inquiry form (Refs #157)

### DIFF
--- a/src/components/Inquiry.tsx
+++ b/src/components/Inquiry.tsx
@@ -194,6 +194,22 @@ export default function Inquiry() {
           <input id="email" name="email" type="email" required className={inputClass} disabled={submitting} />
         </div>
 
+        {/* Phone — sent to Formspree as `phone`; intentionally no strict pattern
+            so common domestic and international formats are all accepted (#157). */}
+        <div className="flex flex-col gap-2">
+          <label htmlFor="phone" className={labelClass}>Phone Number</label>
+          <input
+            id="phone"
+            name="phone"
+            type="tel"
+            autoComplete="tel"
+            inputMode="tel"
+            required
+            className={inputClass}
+            disabled={submitting}
+          />
+        </div>
+
         {/* Interested Service — prefilled from the clicked Services card (#95),
             editable here, and sent to Formspree as `interestedService`. */}
         <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary

Adds a required, accessible **Phone Number** field to the inquiry form so prospective clients can provide a callback number that reaches Amanda/Karan through the existing Formspree submission (Refs #157).

- New field placed immediately after Email and before Interested Service.
- Input uses `name="phone"`, `type="tel"`, `autoComplete="tel"`, `inputMode="tel"`, existing `inputClass` styling, and the shared `disabled={submitting}` behavior.
- Required, participates in native browser validation.
- **No** US-only regex or restrictive formatting mask — accepts `(404) 555-0100`, `404-555-0100`, `+1 404 555 0100`, etc.
- Relies on the existing `new FormData(form)` serialization, so `phone` is included in the Formspree JSON payload automatically with no separate hard-coded payload.
- Existing `motion.form` animation and loading/error/success/reset behavior are unchanged.
- Analytics (`trackEvent`) still receives only the non-personal `service` category. No phone number or other PII is logged to the console, sent to analytics, or exposed via query params.

## Verification evidence

Verified against exact PR head `9b68aa544439724f89ed6e6f662df8b7f9d2b602`:

- `npm run lint` (`tsc --noEmit`) — passes.
- `npm run build` (`vite build`) — passes.
- Self-reviewed `git diff origin/main...HEAD`: single scoped file change (`src/components/Inquiry.tsx`, +16 lines), no unrelated edits, no debug/console code.
- Exact local HEAD, remote branch SHA, and PR `headRefOid` match.
- No automated tests added: the repo has no test framework, and the issue explicitly scopes out adding one for this change.

## Local browser QA completed

- Desktop and 375×812 mobile renders show Phone Number immediately after Email and before Interested Service with existing styling.
- No horizontal overflow, clipping, or overlap was observed.
- The accessible form control exposes the required label and requested `tel` attributes.
- Empty phone input reports native `valueMissing: true`.
- `(404) 555-0100`, `404-555-0100`, and `+1 404 555 0100` all pass the input's native validation; no `pattern` attribute is present.
- For each format, `new FormData(form).get("phone")` returns the entered value.
- Local QA did not submit the form or send a request to Formspree.

## Approval-gated live QA still pending

No live Formspree test submission was made and no external account was mutated. The remaining issue-level acceptance criterion is confirming a clearly labeled test submission in the configured Formspree dashboard and notification email. Because that live criterion remains unmet, this PR intentionally uses `Refs #157`, has no closing reference, and leaves issue #157 open.

---
Built by: Claude Code via Hermes orchestration
Issue: #157
